### PR TITLE
ParameterState: Fix Value edge case, fix nullability (#12179)

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs
@@ -165,12 +165,12 @@ namespace MudBlazor.UnitTests.Components
         /// Tests that ExpandAll method expands all panels.
         /// </summary>
         [Test]
-        public async Task MudExpansionPanel_ExpandAllAync()
+        public async Task MudExpansionPanel_ExpandAllAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -193,9 +193,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task MudExpansionPanel_CollapseAllAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);
@@ -221,9 +221,9 @@ namespace MudBlazor.UnitTests.Components
         public async Task MudExpansionPanel_CollapseAllExceptAsync()
         {
             var panels = Context.RenderComponent<MudExpansionPanels>();
-            var panel1 = new MudExpansionPanel();
-            var panel2 = new MudExpansionPanel();
-            var panel3 = new MudExpansionPanel();
+            var panel1 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel2 = Context.RenderComponent<MudExpansionPanel>().Instance;
+            var panel3 = Context.RenderComponent<MudExpansionPanel>().Instance;
             await panels.Instance.AddPanelAsync(panel1);
             await panels.Instance.AddPanelAsync(panel2);
             await panels.Instance.AddPanelAsync(panel3);

--- a/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
+++ b/src/MudBlazor.UnitTests/State/ParameterStateTests.cs
@@ -90,26 +90,21 @@ public class ParameterStateTests
     public void OnParametersSet_UpdatesValueIfChanged()
     {
         // Arrange
-        var initialValue = 5;
-        const int NewValue = 10;
+        const int InitialValue = 5;
         // ReSharper disable once AccessToModifiedClosure
         var parameterState = ParameterAttachBuilder
             .Create<int>()
-            .WithMetadata(new ParameterMetadata(nameof(initialValue)))
-            .WithGetParameterValueFunc(() => initialValue)
+            .WithMetadata(new ParameterMetadata(nameof(InitialValue)))
+            .WithGetParameterValueFunc(() => InitialValue)
             .Attach();
 
         // Act
         parameterState.OnParametersSet();
 
         // Assert
-        parameterState.Value.Should().Be(initialValue);
-
-        // Act & Assert
-        initialValue = NewValue;
         parameterState.OnParametersSet();
-        parameterState.Value.Should().Be(NewValue);
-        parameterState.InitialValue.Should().Be(0, because: "OnInitialized wasn't called, so InitialValue remains its default for int");
+        parameterState.Value.Should().Be(InitialValue);
+        parameterState.InitialValue.Should().Be(InitialValue);
     }
 
     [Test]

--- a/src/MudBlazor/State/ParameterState.cs
+++ b/src/MudBlazor/State/ParameterState.cs
@@ -21,7 +21,7 @@ public abstract class ParameterState<T>
     /// <summary>
     /// Gets the current value.
     /// </summary>
-    public abstract T? Value { get; }
+    public abstract T Value { get; }
 
     /// <summary>
     /// Gets a value indicating whether the object is initialized.
@@ -38,7 +38,7 @@ public abstract class ParameterState<T>
     /// This value is captured once when the component is initialized and never changes thereafter,
     /// even if the <see cref="Value"/> property changes later.
     /// </remarks>
-    public abstract T? InitialValue { get; }
+    public abstract T InitialValue { get; }
 
     /// <summary>
     /// Set the parameter's value. 
@@ -56,5 +56,5 @@ public abstract class ParameterState<T>
     /// </summary>
     /// <param name="parameterState">The <see cref="ParameterState{T}"/> object to convert.</param>
     /// <returns>The underlying value of type <typeparamref name="T"/>.</returns>
-    public static implicit operator T?(ParameterState<T> parameterState) => parameterState.Value;
+    public static implicit operator T(ParameterState<T> parameterState) => parameterState.Value;
 }

--- a/src/MudBlazor/State/ParameterStateInternalOfT.cs
+++ b/src/MudBlazor/State/ParameterStateInternalOfT.cs
@@ -47,13 +47,60 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
     public bool HasHandler => _parameterChangedHandler is not null;
 
     /// <inheritdoc />
+    [MemberNotNullWhen(true, nameof(_value), nameof(_initialValue))]
     public override bool IsInitialized => _isInitialized;
 
     /// <inheritdoc />
-    public override T? InitialValue => _initialValue;
+    public override T InitialValue
+    {
+        get
+        {
+            if (!IsInitialized)
+            {
+                return _getParameterValueFunc();
+            }
+
+            return _initialValue;
+        }
+    }
 
     /// <inheritdoc/>
-    public override T? Value => _value;
+    /// <remarks>
+    /// <para>
+    /// Some (bad) components may attempt to read parameter values before OnInitialized is called
+    /// (e.g., during SetParametersAsync). In that case, the state is not yet fully initialized,
+    /// and accessing the Value will return null even when the parameter has a default value, such as:
+    /// <code>[Parameter] string MyParameter { get; set; } = "some value";</code>
+    /// <br/>
+    /// To avoid this, if initialization has not yet occurred, fall back to the delegate
+    /// that retrieves the current parameter value.
+    /// <br/>
+    /// Important: Some incorrect tests bypass the normal Blazor lifecycle, which can lead to
+    /// incorrect state being read. For example:
+    /// </para>
+    /// <code>
+    ///      var panels = Context.RenderComponent&lt;MudExpansionPanels&gt;();
+    ///      var panel = new MudExpansionPanel();
+    ///      panels.Instance.AddPanelAsync(panel);
+    /// </code>
+    /// <para>
+    /// In this scenario, MudExpansionPanel is created outside Blazor's lifecycle, so
+    /// AddPanelAsync receives an invalid _expandedState.Value.
+    /// Such test patterns should be avoided—rewrite the tests to follow normal Blazor usage.
+    /// </para>
+    /// </remarks>
+    public override T Value
+    {
+        get
+        {
+            if (!IsInitialized)
+            {
+                return _getParameterValueFunc();
+            }
+
+            return _value;
+        }
+    }
 
     /// <summary>
     /// Gets the function to provide the comparer for the parameter.
@@ -67,14 +114,14 @@ internal class ParameterStateInternal<T> : ParameterState<T>, IParameterComponen
         _eventCallbackFunc = eventCallbackFunc;
         _parameterChangedHandler = parameterChangedHandler;
         _comparer = comparer ?? new ParameterEqualityComparerSwappable<T>(() => EqualityComparer<T>.Default);
-        _lastValue = default;
-        _value = default;
     }
 
     /// <inheritdoc/>
     public override Task SetValueAsync(T value)
     {
-        if (!_comparer.Equals(Value, value))
+        // Avoid using the Value property here because its getter includes an
+        // IsInitialized branch which may cause the SetValueAsync to be skipped.
+        if (!_comparer.Equals(_value, value))
         {
             _value = value;
             var eventCallback = _eventCallbackFunc();


### PR DESCRIPTION
### **User description**
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove nullability from `ParameterState<T>` properties and implicit operator

- Fix `Value` and `InitialValue` to return actual values before initialization

- Update test to properly render components through Blazor lifecycle

- Correct test method naming and improve test assertions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ParameterState Properties"] -->|Remove nullable| B["Value and InitialValue return T"]
  C["Uninitialized State"] -->|Fallback to delegate| B
  D["Test Lifecycle Issues"] -->|Use RenderComponent| E["Proper Blazor Lifecycle"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ParameterState.cs</strong><dd><code>Remove nullability from ParameterState properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/State/ParameterState.cs

<ul><li>Changed <code>Value</code> property return type from <code>T?</code> to <code>T</code><br> <li> Changed <code>InitialValue</code> property return type from <code>T?</code> to <code>T</code><br> <li> Updated implicit operator to return <code>T</code> instead of <code>T?</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/17/files#diff-dea448de15b5dcb85dbc5a693b91f59da60517a34aa9a0c79b88502f7c237123">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ParameterStateInternalOfT.cs</strong><dd><code>Implement fallback logic for uninitialized parameter state</code></dd></summary>
<hr>

src/MudBlazor/State/ParameterStateInternalOfT.cs

<ul><li>Added fallback logic to <code>Value</code> property to return parameter value when <br>not initialized<br> <li> Added fallback logic to <code>InitialValue</code> property to return parameter <br>value when not initialized<br> <li> Added <code>MemberNotNullWhen</code> attribute to <code>IsInitialized</code> property<br> <li> Fixed <code>SetValueAsync</code> to use <code>_value</code> field directly instead of <code>Value</code> <br>property<br> <li> Removed default initialization of <code>_lastValue</code> and <code>_value</code> fields<br> <li> Added comprehensive XML documentation explaining edge cases and test <br>patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/17/files#diff-1ce08d9f74dacc3a2b47bc4e26bd6143ba854eaf127b58d75f5da9f0200b3f34">+52/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ParameterStateTests.cs</strong><dd><code>Simplify ParameterState test assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor.UnitTests/State/ParameterStateTests.cs

<ul><li>Simplified test by removing dynamic value reassignment pattern<br> <li> Changed variable from <code>initialValue</code> to <code>InitialValue</code> constant<br> <li> Removed <code>NewValue</code> constant and related test logic<br> <li> Updated assertions to verify consistent behavior across calls<br> <li> Fixed assertion to check <code>InitialValue</code> equals the parameter value</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/17/files#diff-f7a01e3ea09501a44c1229b800d68ed418751a08d0d9f5e5eb66efd880d9e29b">+5/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ExpansionPanelTests.cs</strong><dd><code>Fix test lifecycle and method naming in expansion panel tests</code></dd></summary>
<hr>

src/MudBlazor.UnitTests/Components/ExpansionPanelTests.cs

<ul><li>Fixed method name typo from <code>MudExpansionPanel_ExpandAllAync</code> to <br><code>MudExpansionPanel_ExpandAllAsync</code><br> <li> Changed panel instantiation to use <code>Context.RenderComponent<MudExpansionPanel>().Instance</code> <br>in three test methods<br> <li> Applied same fix to <code>MudExpansionPanel_ExpandAllAsync</code>, <br><code>MudExpansionPanel_CollapseAllAsync</code>, and <br><code>MudExpansionPanel_CollapseAllExceptAsync</code> tests</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/17/files#diff-ee17b46e6b45aa4b2ceefe6a208c2824d4db836e7cb51620499156e7bf7e2a59">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

