### PR TITLE
hide content after panel closes

### DIFF
--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor
@@ -18,10 +18,10 @@
             <MudIcon Icon="@Icon" class="@(_expandedState.Value ? "mud-expand-panel-icon mud-transform" : "mud-expand-panel-icon")" />
         }
     </div>
-    <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight">
-        @if (KeepContentAlive || _expandedState.Value)
+    <MudCollapse Expanded="_expandedState.Value" MaxHeight="@MaxHeight" OnAnimationEnd="OnAnimationEnd">
+        @if (_renderContent)
         {
-            <div class="@PanelContentClassname" hidden="@(!_expandedState.Value)">
+            <div class="@PanelContentClassname" hidden="@_hidden">
                 @ChildContent
             </div>
         }

--- a/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
+++ b/src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs
@@ -19,6 +19,9 @@ namespace MudBlazor
     {
         internal readonly ParameterState<bool> _expandedState;
 
+        private bool _renderContent;
+        private bool _hidden;
+
         [CascadingParameter]
         private MudExpansionPanels? Parent { get; set; }
 
@@ -178,14 +181,44 @@ namespace MudBlazor
                 .WithChangeHandler(OnExpandedParameterChangedAsync);
         }
 
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            // Set initial content rendering state
+            _renderContent = KeepContentAlive || Expanded;
+            _hidden = !Expanded;
+        }
+
         private Task OnExpandedParameterChangedAsync(ParameterChangedEventArgs<bool> args)
         {
+            var expanded = args.Value;
+            if (KeepContentAlive || expanded)
+            {
+                _renderContent = true;
+            }
+
             if (Parent is null)
             {
                 return Task.CompletedTask;
             }
 
             return Parent.NotifyPanelsChanged(this);
+        }
+
+        private void OnAnimationEnd()
+        {
+            if (KeepContentAlive)
+            {
+                _hidden = !_expandedState.Value;
+                return;
+            }
+
+            if (!_expandedState.Value)
+            {
+                _renderContent = false;
+                StateHasChanged();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add content rendering state management with `_renderContent` and `_hidden` flags

- Implement `OnAnimationEnd` callback to hide content after panel closes

- Initialize rendering state in `OnParametersSet` based on `KeepContentAlive` and `Expanded`

- Update `MudCollapse` to trigger animation end callback and use state flags for visibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Panel State Changes"] --> B["OnExpandedParameterChanged"]
  B --> C["Set _renderContent"]
  D["Animation Completes"] --> E["OnAnimationEnd"]
  E --> F["Update _hidden Flag"]
  F --> G["Hide Content if Not KeepContentAlive"]
  C --> H["MudCollapse Renders"]
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MudExpansionPanel.razor.cs</strong><dd><code>Add state management for content visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor.cs

<ul><li>Add <code>_renderContent</code> and <code>_hidden</code> private fields to track content <br>visibility state<br> <li> Implement <code>OnParametersSet</code> to initialize rendering state based on <br><code>KeepContentAlive</code> and <code>Expanded</code><br> <li> Update <code>OnExpandedParameterChangedAsync</code> to set <code>_renderContent</code> when <br>panel expands<br> <li> Add <code>OnAnimationEnd</code> method to hide content after animation completes, <br>respecting <code>KeepContentAlive</code> setting</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/20/files#diff-231a8821d28ea46042feebba81623d1ac0e1ab27eef2b1bebdac093260e1c1b8">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MudExpansionPanel.razor</strong><dd><code>Update template to use visibility state flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/ExpansionPanel/MudExpansionPanel.razor

<ul><li>Add <code>OnAnimationEnd</code> callback binding to <code>MudCollapse</code> component<br> <li> Replace conditional rendering logic with <code>_renderContent</code> flag<br> <li> Replace inline hidden attribute with <code>_hidden</code> state flag</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/20/files#diff-a627ea274b9ee0db41cfd56fe6752c74594c46e3332097f4c728cf7459570479">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expansion panel animations and content visibility management for more reliable expand/collapse transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->