### PR TITLE
Introduce ColorScheme enum to MudThemeProvider

### DIFF
--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesDarkPaletteExampleSource.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesDarkPaletteExampleSource.razor
@@ -1,11 +1,16 @@
-﻿@namespace MudBlazor.Docs.Examples
+@namespace MudBlazor.Docs.Examples
 
-<MudThemeProvider @bind-IsDarkMode="@_isDarkMode" Theme="_theme"/>
-<MudSwitch @bind-Value="_isDarkMode" Color="Color.Primary" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode"/>
+<MudThemeProvider @bind-ColorScheme="@_colorScheme" Theme="_theme"/>
+<MudSwitch Value="@(_colorScheme == ColorScheme.Dark)" ValueChanged="@OnDarkModeChanged" Color="Color.Primary" Class="ma-4" T="bool" Label="Toggle Light/Dark Mode"/>
 
 <MudText Class="ma-4">This is an example text!</MudText>
 
 @code{
     private MudTheme _theme = new();
-    private bool _isDarkMode;
+    private ColorScheme _colorScheme = ColorScheme.Light;
+
+    private void OnDarkModeChanged(bool isDark)
+    {
+        _colorScheme = isDark ? ColorScheme.Dark : ColorScheme.Light;
+    }
 }

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesSystemPreferenceExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesSystemPreferenceExample.razor
@@ -1,17 +1,20 @@
-﻿@namespace MudBlazor.Docs.Examples
+@namespace MudBlazor.Docs.Examples
 
-<MudThemeProvider @ref="_mudThemeProvider" @bind-IsDarkMode="_isDarkMode"/>
+<MudThemeProvider @ref="_mudThemeProvider" ColorScheme="ColorScheme.System" />
+
+<MudText>Initial system theme preference: @(_isDarkMode ? "Dark" : "Light")</MudText>
 
 @code {
     private bool _isDarkMode;
-    private MudThemeProvider _mudThemeProvider;
+    private MudThemeProvider _mudThemeProvider = null!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
             _isDarkMode = await _mudThemeProvider.GetSystemDarkModeAsync();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
+        await base.OnAfterRenderAsync(firstRender);
     }
 }

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesWatchSystemPreferenceExample.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Examples/OverviewThemesWatchSystemPreferenceExample.razor
@@ -1,24 +1,26 @@
-﻿@namespace MudBlazor.Docs.Examples
+@namespace MudBlazor.Docs.Examples
 
-<MudThemeProvider @ref="_mudThemeProvider" @bind-IsDarkMode="_isDarkMode" />
+<MudThemeProvider @ref="_mudThemeProvider" ColorScheme="ColorScheme.System" ResolvedIsDarkModeChanged="OnSystemModeChanged" />
+
+<MudText>System is currently in @(_isDarkMode ? "Dark" : "Light") mode.</MudText>
 
 @code {
     private bool _isDarkMode;
-    private MudThemeProvider _mudThemeProvider;
+    private MudThemeProvider _mudThemeProvider = null!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (firstRender && _mudThemeProvider is not null)
         {
-            await _mudThemeProvider.WatchSystemDarkModeAsync(OnSystemDarkModeChanged);
-            StateHasChanged();
+            _isDarkMode = _mudThemeProvider.ResolvedIsDarkMode;
+            await InvokeAsync(StateHasChanged);
         }
+        await base.OnAfterRenderAsync(firstRender);
     }
 
-    private Task OnSystemDarkModeChanged(bool newValue)
+    private void OnSystemModeChanged(bool newValue)
     {
         _isDarkMode = newValue;
         StateHasChanged();
-        return Task.CompletedTask;
     }
 }

--- a/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
+++ b/src/MudBlazor.Docs/Pages/Customization/Theming/Overview.razor
@@ -39,7 +39,7 @@
 
         <DocsPageSection>
             <SectionHeader Title="Dark Palette">
-                <Description>Dark palettes are integrated into <CodeInline>MudTheme</CodeInline>. Just set <CodeInline>IsDarkMode</CodeInline> to <CodeInline>true</CodeInline>.</Description>
+                <Description>Dark palettes are integrated into <CodeInline>MudTheme</CodeInline>. Just set <CodeInline>ColorScheme</CodeInline> to <CodeInline>ColorScheme.Dark</CodeInline>.</Description>
             </SectionHeader>
             <SectionContent Code="@nameof(OverviewThemesDarkPaletteExampleSource)">
                 <OverviewThemesDarkPaletteExample/>

--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor.Docs/Services/LayoutService.cs
+++ b/src/MudBlazor.Docs/Services/LayoutService.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using MudBlazor.Docs.Enums;
+using MudBlazor;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services.UserPreferences;
 
@@ -20,21 +20,14 @@ public class LayoutService
     public bool IsRTL { get; private set; }
 
     /// <summary>
-    /// The user's preferred dark/light mode setting.
-    /// This preference is used to determine the actual <see cref="IsDarkMode"/> state.
+    /// The user's preferred color scheme setting.
     /// </summary>
-    public DarkLightMode CurrentDarkLightMode { get; private set; }
+    public ColorScheme CurrentColorScheme { get; private set; }
 
     /// <summary>
     /// Dark mode is currently active.
-    /// This is determined by <see cref="UpdateDarkModeAsync"/> based on user and system preferences and should not be modified directly.
     /// </summary>
     public bool IsDarkMode { get; private set; }
-
-    /// <summary>
-    /// Observes system theme changes to update dark/light mode.
-    /// </summary>
-    public bool ObserveSystemDarkModeChange { get; private set; }
 
     /// <summary>
     /// The currently active MudBlazor theme.
@@ -64,10 +57,10 @@ public class LayoutService
             _systemDarkMode = systemMode.Value;
         }
 
-        IsDarkMode = CurrentDarkLightMode switch
+        IsDarkMode = CurrentColorScheme switch
         {
-            DarkLightMode.Dark => true,
-            DarkLightMode.Light => false,
+            ColorScheme.Dark => true,
+            ColorScheme.Light => false,
             _ => _systemDarkMode,
         };
     }
@@ -81,14 +74,14 @@ public class LayoutService
             _userPreferences = new()
             {
                 RightToLeft = false,
-                DarkLightTheme = DarkLightMode.System,
+                DarkLightTheme = ColorScheme.System,
             };
             await _userPreferencesService.SaveUserPreferences(_userPreferences);
         }
         else
         {
             IsRTL = _userPreferences.RightToLeft;
-            CurrentDarkLightMode = _userPreferences.DarkLightTheme;
+            CurrentColorScheme = _userPreferences.DarkLightTheme;
             UpdateDarkModeState();
         }
     }
@@ -106,22 +99,21 @@ public class LayoutService
     }
 
     /// <summary>
-    /// Cycles through the available dark/light mode options (System, Light, Dark) and saves the new preference.
+    /// Cycles through the available color scheme options (System, Light, Dark) and saves the new preference.
     /// </summary>
-    public async Task CycleDarkLightModeAsync()
+    public async Task CycleColorSchemeAsync()
     {
-        CurrentDarkLightMode = CurrentDarkLightMode switch
+        CurrentColorScheme = CurrentColorScheme switch
         {
-            DarkLightMode.System => DarkLightMode.Light,
-            DarkLightMode.Light => DarkLightMode.Dark,
-            DarkLightMode.Dark => DarkLightMode.System,
-            _ => DarkLightMode.System, // Default case, should not happen.
+            ColorScheme.System => ColorScheme.Light,
+            ColorScheme.Light => ColorScheme.Dark,
+            ColorScheme.Dark => ColorScheme.System,
+            _ => ColorScheme.System, // Default case, should not happen.
         };
 
-        ObserveSystemDarkModeChange = CurrentDarkLightMode == DarkLightMode.System;
         UpdateDarkModeState();
 
-        _userPreferences.DarkLightTheme = CurrentDarkLightMode;
+        _userPreferences.DarkLightTheme = CurrentColorScheme;
         await _userPreferencesService.SaveUserPreferences(_userPreferences);
         OnMajorUpdateOccurred();
     }

--- a/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
+++ b/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
+++ b/src/MudBlazor.Docs/Services/UserPreferences/UserPreferences.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using MudBlazor.Docs.Enums;
+using MudBlazor;
 
 namespace MudBlazor.Docs.Services.UserPreferences
 {
@@ -16,6 +16,6 @@ namespace MudBlazor.Docs.Services.UserPreferences
         /// <summary>
         /// The preferred dark mode configuration.
         /// </summary>
-        public DarkLightMode DarkLightTheme { get; set; }
+        public ColorScheme DarkLightTheme { get; set; }
     }
 }

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor
@@ -33,6 +33,6 @@
     <MudIconButton OnClick="@LayoutService.ToggleRightToLeftAsync" Icon="@RtlButtonIcon" Color="Color.Inherit" aria-label="@RtlButtonText" />
 </MudTooltip>
 
-<MudTooltip Text="@DarkLightModeButtonText">
-    <MudIconButton OnClick="@LayoutService.CycleDarkLightModeAsync" Icon="@DarkLightModeButtonIcon" Color="Color.Inherit" aria-label="@DarkLightModeButtonText" />
+<MudTooltip Text="@ColorSchemeButtonText">
+    <MudIconButton OnClick="@LayoutService.CycleColorSchemeAsync" Icon="@ColorSchemeButtonIcon" Color="Color.Inherit" aria-label="@ColorSchemeButtonText" />
 </MudTooltip>

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) MudBlazor 2021
+﻿// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 

--- a/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
+++ b/src/MudBlazor.Docs/Shared/AppbarButtons.razor.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
-using MudBlazor.Docs.Enums;
+using MudBlazor;
 using MudBlazor.Docs.Services;
 using MudBlazor.Docs.Services.Notifications;
 
@@ -31,22 +31,22 @@ public partial class AppbarButtons
     public string RtlButtonIcon => LayoutService.IsRTL ? @Icons.Material.Filled.FormatTextdirectionLToR : @Icons.Material.Filled.FormatTextdirectionRToL;
 
     /// <summary>
-    /// Gets the text for the dark/light mode toggle button, indicating the next mode.
+    /// Gets the text for the color scheme toggle button, indicating the next mode.
     /// </summary>
-    public string DarkLightModeButtonText => LayoutService.CurrentDarkLightMode switch
+    public string ColorSchemeButtonText => LayoutService.CurrentColorScheme switch
     {
-        DarkLightMode.Dark => "Auto mode",
-        DarkLightMode.Light => "Dark mode",
+        ColorScheme.Dark => "Auto mode",
+        ColorScheme.Light => "Dark mode",
         _ => "Light mode"
     };
 
     /// <summary>
-    /// Gets the icon for the dark/light mode toggle button.
+    /// Gets the icon for the color scheme toggle button.
     /// </summary>
-    public string DarkLightModeButtonIcon => LayoutService.CurrentDarkLightMode switch
+    public string ColorSchemeButtonIcon => LayoutService.CurrentColorScheme switch
     {
-        DarkLightMode.Dark => Icons.Material.Rounded.AutoMode,
-        DarkLightMode.Light => Icons.Material.Outlined.DarkMode,
+        ColorScheme.Dark => Icons.Material.Rounded.AutoMode,
+        ColorScheme.Light => Icons.Material.Outlined.DarkMode,
         _ => Icons.Material.Filled.LightMode
     };
 

--- a/src/MudBlazor.Docs/Shared/MainLayout.razor
+++ b/src/MudBlazor.Docs/Shared/MainLayout.razor
@@ -1,7 +1,7 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
 <MudRTLProvider RightToLeft="@LayoutService.IsRTL">
-    <MudThemeProvider @ref="@_mudThemeProvider" Theme="@LayoutService.CurrentTheme" ObserveSystemDarkModeChange="@LayoutService.ObserveSystemDarkModeChange" IsDarkMode="@LayoutService.IsDarkMode" IsDarkModeChanged="@((dark) => LayoutService.UpdateDarkModeState(dark))" />
+    <MudThemeProvider @ref="@_mudThemeProvider" Theme="@LayoutService.CurrentTheme" ColorScheme="@LayoutService.CurrentColorScheme" ResolvedIsDarkModeChanged="@((dark) => LayoutService.OnSystemModeChangedAsync(dark))" />
     <MudPopoverProvider />
     <MudSnackbarProvider/>
     <MudDialogProvider FullWidth="true" MaxWidth="MaxWidth.ExtraSmall"/>

--- a/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Pages/Index.razor
@@ -1,10 +1,11 @@
-﻿@page "/"
+@page "/"
+@using MudBlazor
 @using System.Reflection
 @using FuzzySharp
 @inject NavigationManager NavManager
 @implements IDisposable
 
-<MudThemeProvider Theme="@_customTheme" IsDarkMode="@_isDarkMode" />
+<MudThemeProvider Theme="@_customTheme" ColorScheme="@_colorScheme" />
 
 <MudLayout>
     <MudRTLProvider RightToLeft="_rightToLeft">
@@ -217,7 +218,7 @@
     private bool _canShowAllLink;
     private CancellationTokenSource? _searchCts;
     private Task? _searchTask;
-    private bool _isDarkMode;
+    private MudBlazor.ColorScheme _colorScheme = MudBlazor.ColorScheme.Light;
     private readonly MudTheme _customTheme = new()
     {
         LayoutProperties = new LayoutProperties
@@ -227,11 +228,11 @@
         }
     };
 
-    private void ToggleTheme() => _isDarkMode = !_isDarkMode;
+    private void ToggleTheme() => _colorScheme = _colorScheme == MudBlazor.ColorScheme.Dark ? MudBlazor.ColorScheme.Light : MudBlazor.ColorScheme.Dark;
 
-    private string ThemeIcon => _isDarkMode ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode;
+    private string ThemeIcon => _colorScheme == MudBlazor.ColorScheme.Dark ? Icons.Material.Filled.LightMode : Icons.Material.Filled.DarkMode;
 
-    private string ThemeLabel => _isDarkMode ? "Light mode" : "Dark mode";
+    private string ThemeLabel => _colorScheme == MudBlazor.ColorScheme.Dark ? "Light mode" : "Dark mode";
 
     private string SearchText
     {

--- a/src/MudBlazor.UnitTests.Viewer/Shared/MainLayoutTwo.razor
+++ b/src/MudBlazor.UnitTests.Viewer/Shared/MainLayoutTwo.razor
@@ -1,8 +1,8 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
 <MudDialogProvider/>
 <MudSnackbarProvider/>
-<MudThemeProvider Theme="@_customTheme" IsDarkMode="@false"  />
+<MudThemeProvider Theme="@_customTheme" ColorScheme="ColorScheme.Light"  />
 
 @Body
 

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ThemeProvider/ThemeProviderCurrentPaletteTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ThemeProvider/ThemeProviderCurrentPaletteTest.razor
@@ -1,20 +1,20 @@
 @using MudBlazor
 
-<MudThemeProvider @bind-IsDarkMode="_isDarkMode" @bind-CurrentPalette="_currentPalette" />
+<MudThemeProvider @bind-ColorScheme="_colorScheme" @bind-CurrentPalette="_currentPalette" />
 
-<MudText>Dark Mode: @_isDarkMode</MudText>
+<MudText>Color Scheme: @_colorScheme</MudText>
 <MudText>Current Palette Type: @_currentPalette?.GetType().Name</MudText>
 <MudText>Primary Color: @_currentPalette?.Primary</MudText>
 
 <MudButton OnClick="ToggleDarkMode">Toggle Dark Mode</MudButton>
 
 @code {
-    private bool _isDarkMode;
+    private MudBlazor.ColorScheme _colorScheme = MudBlazor.ColorScheme.Light;
     private Palette? _currentPalette;
 
     private void ToggleDarkMode()
     {
-        _isDarkMode = !_isDarkMode;
+        _colorScheme = _colorScheme == MudBlazor.ColorScheme.Dark ? MudBlazor.ColorScheme.Light : MudBlazor.ColorScheme.Dark;
     }
 
     public Palette? GetCurrentPalette() => _currentPalette;

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/ThemeProvider/ThemeProviderObserveSystemDarkModeChangeTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/ThemeProvider/ThemeProviderObserveSystemDarkModeChangeTest.razor
@@ -1,17 +1,18 @@
-﻿<MudThemeProvider ObserveSystemDarkModeChange="@_observeSystemDarkModeChange" />
+@using MudBlazor
+<MudThemeProvider ColorScheme="@_colorScheme" />
 
 @code {
-    private bool _observeSystemDarkModeChange;
+    private ColorScheme _colorScheme = ColorScheme.Light;
 
     public void EnableObserve()
     {
-        _observeSystemDarkModeChange = true;
+        _colorScheme = ColorScheme.System;
         StateHasChanged();
     }
 
     public void DisableObserve()
     {
-        _observeSystemDarkModeChange = false;
+        _colorScheme = ColorScheme.Light;
         StateHasChanged();
     }
 }

--- a/src/MudBlazor.UnitTests/Components/ColorSchemeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorSchemeTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AwesomeAssertions;
 using Bunit;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor.UnitTests/Components/ColorSchemeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ColorSchemeTests.cs
@@ -1,0 +1,103 @@
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using MudBlazor.UnitTests.Mocks;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ColorSchemeTests : BunitTest
+    {
+        [Test]
+        public void ColorScheme_Light_ForcesLightMode()
+        {
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Light));
+
+            comp.Instance.ResolvedIsDarkMode.Should().BeFalse();
+        }
+
+        [Test]
+        public void ColorScheme_Dark_ForcesDarkMode()
+        {
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Dark));
+
+            comp.Instance.ResolvedIsDarkMode.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ColorScheme_System_ResolvesFromJS()
+        {
+            Context.JSInterop.Setup<bool>("mudThemeProvider.isDarkMode").SetResult(true);
+
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.System));
+
+            // Resolution happens after render
+            await comp.InvokeAsync(() => { }); // trigger render/afterrender
+
+            comp.Instance.ResolvedIsDarkMode.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ColorScheme_Switching_UpdatesState()
+        {
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Light));
+
+            comp.Instance.ResolvedIsDarkMode.Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ColorScheme, ColorScheme.Dark));
+            comp.Instance.ResolvedIsDarkMode.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ResolvedIsDarkModeChanged_Fires()
+        {
+            bool? resolvedValue = null;
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Light)
+                .Add(p => p.ResolvedIsDarkModeChanged, EventCallback.Factory.Create<bool>(this, (bool val) => resolvedValue = val)));
+
+            resolvedValue.Should().BeFalse();
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ColorScheme, ColorScheme.Dark));
+            resolvedValue.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task ColorScheme_System_StartsWatching()
+        {
+            Context.JSInterop.SetupVoid("mudThemeProvider.watchDarkMode");
+
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.System));
+
+            await comp.InvokeAsync(() => { }); // ensure afterrender
+
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
+        }
+
+        [Test]
+        public async Task ColorScheme_Forced_StopsWatching()
+        {
+            Context.JSInterop.SetupVoid("mudThemeProvider.watchDarkMode");
+            Context.JSInterop.SetupVoid("mudThemeProvider.stopWatchingDarkMode");
+
+            var comp = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.System));
+
+            await comp.InvokeAsync(() => { });
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.ColorScheme, ColorScheme.Dark));
+
+            Context.JSInterop.VerifyInvoke("mudThemeProvider.stopWatchingDarkMode", 1);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;

--- a/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ThemeProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using AngleSharp.Html.Dom;
 using AwesomeAssertions;
 using Bunit;
@@ -11,9 +11,17 @@ using NUnit.Framework;
 namespace MudBlazor.UnitTests.Components
 {
 #nullable enable
+#pragma warning disable CS0618
     [TestFixture]
     public class ThemeProviderTests : BunitTest
     {
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            Context.JSInterop.Setup<bool>("mudThemeProvider.isDarkMode").SetResult(false);
+        }
+
         [Test]
         [TestCase("en-us")]
         [TestCase("de-DE")]
@@ -403,31 +411,34 @@ namespace MudBlazor.UnitTests.Components
             styleLines.Should().Contain(expectedPrimaryDarkenLine);
         }
 
+
         [Test]
         public async Task ObserveSystemDarkModeChange()
         {
             // Arrange & Act
             Context.JSInterop.SetupVoid("mudThemeProvider.stopWatchingDarkMode");
             Context.JSInterop.SetupVoid("mudThemeProvider.watchDarkMode");
-            var themeProvider = Context.Render<ThemeProviderObserveSystemDarkModeChangeTest>();
+            var themeProvider = Context.Render<MudThemeProvider>(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Light));
 
             // Assert
             Context.JSInterop.VerifyNotInvoke("mudThemeProvider.watchDarkMode");
             Context.JSInterop.VerifyNotInvoke("mudThemeProvider.stopWatchingDarkMode");
 
             // Act
-            await themeProvider.InvokeAsync(themeProvider.Instance.EnableObserve);
+            await themeProvider.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.System));
 
             // Assert
-            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
+            themeProvider.WaitForAssertion(() => Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1));
             Context.JSInterop.VerifyNotInvoke("mudThemeProvider.stopWatchingDarkMode");
 
             // Act
-            await themeProvider.InvokeAsync(themeProvider.Instance.DisableObserve);
+            await themeProvider.SetParametersAndRenderAsync(parameters => parameters
+                .Add(p => p.ColorScheme, ColorScheme.Light));
 
             // Assert
-            Context.JSInterop.VerifyInvoke("mudThemeProvider.watchDarkMode", 1);
-            Context.JSInterop.VerifyInvoke("mudThemeProvider.stopWatchingDarkMode", 1);
+            themeProvider.WaitForAssertion(() => Context.JSInterop.VerifyInvoke("mudThemeProvider.stopWatchingDarkMode", 1));
         }
 
         [Test]
@@ -672,4 +683,5 @@ namespace MudBlazor.UnitTests.Components
             comp.Instance.GetCurrentPalette().Should().BeOfType<PaletteLight>();
         }
     }
+#pragma warning restore CS0618
 }

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Components;
@@ -16,9 +16,10 @@ namespace MudBlazor;
 /// <seealso cref="MudTheme"/>
 partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
 {
-    // private const string Breakpoint = "mud-breakpoint";
     private bool _disposed;
     private bool _observing;
+    private bool _isInitialized;
+    private bool? _lastResolvedIsDarkMode;
     private const string Palette = "mud-palette";
     private const string Ripple = "mud-ripple";
     private const string Elevation = "mud-elevation";
@@ -30,6 +31,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     private readonly ParameterState<bool> _isDarkModeState;
     private readonly ParameterState<Palette?> _currentPaletteState;
     private readonly ParameterState<bool> _observeSystemDarkModeChangeState;
+    private readonly ParameterState<ColorScheme> _colorSchemeState;
     private readonly Lazy<DotNetObjectReference<MudThemeProvider>> _lazyDotNetRef;
 
     private event Func<bool, Task>? DarkModeChanged;
@@ -53,6 +55,21 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     public bool DefaultScrollbar { get; set; }
 
     /// <summary>
+    /// The preference for dark or light mode.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="ColorScheme.System"/>.
+    /// </remarks>
+    [Parameter, ParameterState]
+    public ColorScheme ColorScheme { get; set; } = ColorScheme.System;
+
+    /// <summary>
+    /// Occurs when <see cref="ColorScheme"/> has changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<ColorScheme> ColorSchemeChanged { get; set; }
+
+    /// <summary>
     /// Detects when the system theme has changed between Light Mode and Dark Mode.
     /// </summary>
     /// <remarks>
@@ -60,6 +77,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// When <c>true</c>, the theme will automatically change to Light Mode or Dark Mode as the system theme changes.
     /// </remarks>
     [Parameter, ParameterState]
+    [Obsolete("Use ColorScheme instead.")]
     public bool ObserveSystemDarkModeChange { get; set; } = true;
 
     /// <summary>
@@ -70,13 +88,26 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// When this value changes, <see cref="IsDarkModeChanged"/> occurs.
     /// </remarks>
     [Parameter, ParameterState]
+    [Obsolete("Use ColorScheme instead.")]
     public bool IsDarkMode { get; set; }
 
     /// <summary>
     /// Occurs when <see cref="IsDarkMode"/> has changed.
     /// </summary>
     [Parameter]
+    [Obsolete("Use ColorSchemeChanged instead.")]
     public EventCallback<bool> IsDarkModeChanged { get; set; }
+
+    /// <summary>
+    /// Gets the currently resolved dark mode state.
+    /// </summary>
+    public bool ResolvedIsDarkMode => _isDarkModeState.Value;
+
+    /// <summary>
+    /// Occurs when the resolved dark mode state has changed.
+    /// </summary>
+    [Parameter]
+    public EventCallback<bool> ResolvedIsDarkModeChanged { get; set; }
 
     /// <summary>
     /// Gets the currently active palette based on the <see cref="IsDarkMode"/> setting.
@@ -98,12 +129,19 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     public MudThemeProvider()
     {
         using var registerScope = CreateRegisterScope();
+#pragma warning disable CS0618
         _isDarkModeState = registerScope.RegisterParameter<bool>(nameof(IsDarkMode))
             .WithParameter(() => IsDarkMode)
-            .WithEventCallback(() => IsDarkModeChanged);
+            .WithEventCallback(() => IsDarkModeChanged)
+            .WithChangeHandler(OnIsDarkModeChanged);
         _observeSystemDarkModeChangeState = registerScope.RegisterParameter<bool>(nameof(ObserveSystemDarkModeChange))
             .WithParameter(() => ObserveSystemDarkModeChange)
             .WithChangeHandler(OnObserveSystemDarkModeChangeChanged);
+#pragma warning restore CS0618
+        _colorSchemeState = registerScope.RegisterParameter<ColorScheme>(nameof(ColorScheme))
+            .WithParameter(() => ColorScheme)
+            .WithEventCallback(() => ColorSchemeChanged)
+            .WithChangeHandler(OnColorSchemeChanged);
         _currentPaletteState = registerScope.RegisterParameter<Palette?>(nameof(CurrentPalette))
             .WithParameter(() => CurrentPalette)
             .WithEventCallback(() => CurrentPaletteChanged);
@@ -118,8 +156,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// </returns>
     public async Task<bool> GetSystemDarkModeAsync()
     {
-        var (_, value) = await JsRuntime.InvokeAsyncWithErrorHandling(false, "mudThemeProvider.isDarkMode");
-        return value;
+        var (_, isDarkMode) = await JsRuntime.InvokeAsyncWithErrorHandling(false, "mudThemeProvider.isDarkMode");
+        return isDarkMode;
     }
 
     /// <summary>
@@ -142,12 +180,17 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     [JSInvokable]
     public async Task SystemDarkModeChangedAsync(bool isDarkMode)
     {
-        await _isDarkModeState.SetValueAsync(isDarkMode);
-        var handler = DarkModeChanged;
-        if (handler is not null)
+#pragma warning disable CS0618
+        if (_colorSchemeState.Value == ColorScheme.System || _observeSystemDarkModeChangeState.Value)
         {
-            await handler(isDarkMode);
+            await _isDarkModeState.SetValueAsync(isDarkMode);
+            var handler = DarkModeChanged;
+            if (handler is not null)
+            {
+                await handler(isDarkMode);
+            }
         }
+#pragma warning restore CS0618
     }
 
     // <inheritdoc />
@@ -155,11 +198,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     {
         if (firstRender)
         {
-            if (_observeSystemDarkModeChangeState.Value && !_observing)
-            {
-                _observing = true;
-                await WatchDarkMode();
-            }
+            _isInitialized = true;
+            await UpdateThemeStateAsync();
         }
 
         await base.OnAfterRenderAsync(firstRender);
@@ -168,7 +208,17 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     // <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
-        await _currentPaletteState.SetValueAsync(GetCurrentPalette());
+#pragma warning disable CS0618
+        if (_colorSchemeState.Value == ColorScheme.System && !_observeSystemDarkModeChangeState.Value)
+        {
+            await _colorSchemeState.SetValueAsync(_isDarkModeState.Value ? ColorScheme.Dark : ColorScheme.Light);
+        }
+#pragma warning restore CS0618
+
+        if (_isInitialized)
+        {
+            await SyncThemeStateAsync(_isDarkModeState.Value);
+        }
 
         await base.OnParametersSetAsync();
     }
@@ -574,13 +624,73 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         return _isDarkModeState.Value ? theme.PaletteDark : theme.PaletteLight;
     }
 
-    private async Task OnObserveSystemDarkModeChangeChanged(ParameterChangedEventArgs<bool> arg)
+    private async Task OnIsDarkModeChanged(ParameterChangedEventArgs<bool> arg)
     {
-        // The _observing flag prevents attempting to stop observation when it hasn't been started.
-        // For example, ObserveSystemDarkModeChange is true by default, and if it's set to false in the initial component setup 
-        // like <MudThemeProvider ObserveSystemDarkModeChange="false" />, the ChangeHandler of ParameterState will be invoked.
-        // Therefore, it's not desirable to stop an observation that hasn't been started.
-        if (arg.Value)
+        if (_colorSchemeState.Value != ColorScheme.System)
+        {
+            await _colorSchemeState.SetValueAsync(arg.Value ? ColorScheme.Dark : ColorScheme.Light);
+        }
+        await UpdateThemeStateAsync();
+    }
+
+    private async Task SyncThemeStateAsync(bool isDarkMode)
+    {
+        var theme = GetTheme();
+        await _currentPaletteState.SetValueAsync(isDarkMode ? theme.PaletteDark : theme.PaletteLight);
+
+        if (_lastResolvedIsDarkMode != isDarkMode)
+        {
+            _lastResolvedIsDarkMode = isDarkMode;
+            await ResolvedIsDarkModeChanged.InvokeAsync(isDarkMode);
+        }
+    }
+
+    private async Task OnColorSchemeChanged(ParameterChangedEventArgs<ColorScheme> arg)
+    {
+        await UpdateThemeStateAsync();
+    }
+
+    private async Task UpdateThemeStateAsync()
+    {
+#pragma warning disable CS0618
+        var colorScheme = _colorSchemeState.Value;
+        var observeSystem = _observeSystemDarkModeChangeState.Value;
+        var isDarkMode = _isDarkModeState.Value;
+
+        switch (colorScheme)
+        {
+            case ColorScheme.Light:
+                isDarkMode = false;
+                observeSystem = false;
+                break;
+            case ColorScheme.Dark:
+                isDarkMode = true;
+                observeSystem = false;
+                break;
+            case ColorScheme.System:
+                observeSystem = true;
+                // For backward compatibility: if IsDarkMode was already true, we don't immediately override it with system preference.
+                if (!isDarkMode && _isInitialized)
+                {
+                    isDarkMode = await GetSystemDarkModeAsync();
+                }
+                break;
+        }
+
+        await _isDarkModeState.SetValueAsync(isDarkMode);
+        await _observeSystemDarkModeChangeState.SetValueAsync(observeSystem);
+
+        await SyncThemeStateAsync(isDarkMode);
+        await SyncThemeWatchingAsync();
+#pragma warning restore CS0618
+    }
+
+    private async Task SyncThemeWatchingAsync()
+    {
+#pragma warning disable CS0618
+        bool shouldObserve = _colorSchemeState.Value == ColorScheme.System && _observeSystemDarkModeChangeState.Value;
+#pragma warning restore CS0618
+        if (shouldObserve)
         {
             if (!_observing)
             {
@@ -596,6 +706,27 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
                 await StopWatchingDarkMode();
             }
         }
+    }
+
+    private async Task OnObserveSystemDarkModeChangeChanged(ParameterChangedEventArgs<bool> arg)
+    {
+        // Update ColorScheme to match ObserveSystemDarkModeChange for backward compatibility
+        if (arg.Value)
+        {
+            if (_colorSchemeState.Value != ColorScheme.System)
+            {
+                await _colorSchemeState.SetValueAsync(ColorScheme.System);
+            }
+        }
+        else
+        {
+            if (_colorSchemeState.Value == ColorScheme.System)
+            {
+                await _colorSchemeState.SetValueAsync(_isDarkModeState.Value ? ColorScheme.Dark : ColorScheme.Light);
+            }
+        }
+
+        await UpdateThemeStateAsync();
     }
 
     private ValueTask WatchDarkMode() => JsRuntime.InvokeVoidAsyncIgnoreErrors("mudThemeProvider.watchDarkMode", _lazyDotNetRef.Value);

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -77,7 +77,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// When <c>true</c>, the theme will automatically change to Light Mode or Dark Mode as the system theme changes.
     /// </remarks>
     [Parameter, ParameterState]
-    [Obsolete("Use ColorScheme instead.")]
+    [Obsolete("Use ColorScheme.System instead.")]
     public bool ObserveSystemDarkModeChange { get; set; } = true;
 
     /// <summary>
@@ -88,7 +88,7 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
     /// When this value changes, <see cref="IsDarkModeChanged"/> occurs.
     /// </remarks>
     [Parameter, ParameterState]
-    [Obsolete("Use ColorScheme instead.")]
+    [Obsolete("Use ColorScheme.Dark or ColorScheme.Light instead.")]
     public bool IsDarkMode { get; set; }
 
     /// <summary>
@@ -624,12 +624,15 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         return _isDarkModeState.Value ? theme.PaletteDark : theme.PaletteLight;
     }
 
+    // Handler to sync IsDarkMode -> ColorScheme
+    //TODO: remove when obsolete parameter IsDarkMode is removed
     private async Task OnIsDarkModeChanged(ParameterChangedEventArgs<bool> arg)
     {
         if (_colorSchemeState.Value != ColorScheme.System)
         {
             await _colorSchemeState.SetValueAsync(arg.Value ? ColorScheme.Dark : ColorScheme.Light);
         }
+
         await UpdateThemeStateAsync();
     }
 
@@ -708,6 +711,8 @@ partial class MudThemeProvider : ComponentBaseWithState, IAsyncDisposable
         }
     }
 
+    // Handler to sync ObserveSystemDarkModeChange -> ColorScheme
+    //TODO: remove when obsolete parameter ObserveSystemDarkModeChange is removed
     private async Task OnObserveSystemDarkModeChangeChanged(ParameterChangedEventArgs<bool> arg)
     {
         // Update ColorScheme to match ObserveSystemDarkModeChange for backward compatibility

--- a/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
+++ b/src/MudBlazor/Components/ThemeProvider/MudThemeProvider.razor.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Components;

--- a/src/MudBlazor/Enums/ColorScheme.cs
+++ b/src/MudBlazor/Enums/ColorScheme.cs
@@ -1,4 +1,4 @@
-namespace MudBlazor;
+﻿namespace MudBlazor;
 
 /// <summary>
 /// Represents the theme preference for dark or light mode.

--- a/src/MudBlazor/Enums/ColorScheme.cs
+++ b/src/MudBlazor/Enums/ColorScheme.cs
@@ -1,9 +1,9 @@
-﻿namespace MudBlazor.Docs.Enums;
+namespace MudBlazor;
 
 /// <summary>
 /// Represents the theme preference for dark or light mode.
 /// </summary>
-public enum DarkLightMode
+public enum ColorScheme
 {
     /// <summary>
     /// The theme is determined by the operating system or browser.

--- a/src/bun.lock
+++ b/src/bun.lock
@@ -1,11 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "dependencies": {
         "eslint": "^9.39.2",
-        "sass": "^1.97.2",
+        "sass": "^1.97.3",
       },
     },
   },
@@ -203,7 +202,7 @@
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "sass": ["sass@1.97.2", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw=="],
+    "sass": ["sass@1.97.3", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "eslint": "^9.39.2",
-    "sass": "^1.97.2"
+    "sass": "^1.97.3"
   },
   "trustedDependencies": ["sass"]
 }


### PR DESCRIPTION
### **User description**
The `ColorScheme` enum provides a cleaner API for managing dark mode and system preference observation. It eliminates contradictory states (like forcing dark mode while still observing system changes) and provides a single event (`ResolvedIsDarkModeChanged`) to track the actual theme state when in `System` mode. Legacy properties are preserved for backward compatibility but marked as obsolete.

---
*PR created automatically by Jules for task [16808647400874833351](https://jules.google.com/task/16808647400874833351) started by @Anu6is*


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce `ColorScheme` enum to replace legacy dark mode properties
  - Provides cleaner API with `System`, `Light`, and `Dark` options
  - Eliminates contradictory states in theme management

- Add `ResolvedIsDarkMode` property and `ResolvedIsDarkModeChanged` event
  - Tracks actual theme state when in `System` mode
  - Single source of truth for theme resolution

- Mark legacy `IsDarkMode` and `ObserveSystemDarkModeChange` as obsolete
  - Full backward compatibility maintained
  - Automatic migration logic for legacy properties

- Migrate documentation and examples to new `ColorScheme` API
  - Update `LayoutService`, theming examples, and test components
  - Add comprehensive `ColorSchemeTests` test suite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy Properties<br/>IsDarkMode<br/>ObserveSystemDarkModeChange"] -->|"Marked Obsolete"| B["ColorScheme Enum<br/>System/Light/Dark"]
  B -->|"Resolves to"| C["ResolvedIsDarkMode<br/>ResolvedIsDarkModeChanged"]
  D["MudThemeProvider"] -->|"Uses"| B
  D -->|"Emits"| C
  E["Documentation<br/>Examples"] -->|"Migrated to"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>ColorScheme.cs</strong><dd><code>Move ColorScheme enum to MudBlazor namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-6c6bbc1970043808f5eebc0e1965c03e1b7dc1b8a634b6a7782ffce526ff8f8f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MudThemeProvider.razor.cs</strong><dd><code>Add ColorScheme parameter and theme resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-22e4a7c3f6c511fade4d85c1b9314d493242cbe4cf54fa49cc8bfb1407422387">+152/-21</a></td>

</tr>

<tr>
  <td><strong>LayoutService.cs</strong><dd><code>Replace DarkLightMode with ColorScheme enum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-10b5cd171a91a6d0a295d5b776cf8a7a6acca61d1caed0f5eae0ad7d1313dba5">+17/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>UserPreferences.cs</strong><dd><code>Update DarkLightTheme property to use ColorScheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-042ef762572035510dadcb1a0469a768b23a5959666bb7987db60bc9f1ee4a17">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AppbarButtons.razor.cs</strong><dd><code>Migrate theme toggle to ColorScheme API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-7ebbdb0e4ac0a3a971b6273380a765d69ffb63cc403f2992cdd82382f5677760">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AppbarButtons.razor</strong><dd><code>Update button text and icon properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-898fe3e47f2c05d93170c776109a51206f2211baf3e3ae34af6505f9bd60fcf3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainLayout.razor</strong><dd><code>Use ColorScheme and ResolvedIsDarkModeChanged</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-e1a3d4bfe649e2c8c339cd562fa66f70877e279a37f5e43ce49c934d39b19171">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OverviewThemesDarkPaletteExampleSource.razor</strong><dd><code>Migrate example to use ColorScheme binding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-b456f580e578c8fc0a1738faee9935fce41ba5f380133f31c17625363c67ec6b">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OverviewThemesSystemPreferenceExample.razor</strong><dd><code>Update example to use ColorScheme.System</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-64d92fcdc47c634352664ad29d64e760c53c09b4d21c87f8e771d7b6090e3bc6">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OverviewThemesWatchSystemPreferenceExample.razor</strong><dd><code>Use ResolvedIsDarkModeChanged event callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-71df527a40453768cf35ee7f769b8465ff5fdcaae72166ccbdee061d470fe49c">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Index.razor</strong><dd><code>Replace IsDarkMode with ColorScheme property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-7c955a80937d2482391e2599e1dd0988109efc67f7ed32af48634e025a87b00a">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainLayoutTwo.razor</strong><dd><code>Update to use ColorScheme.Light</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-ba0f31a431e73a6f7951cead010f73a81a5b7d96a9e416a8dcbb69b969747b41">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ThemeProviderCurrentPaletteTest.razor</strong><dd><code>Migrate test component to ColorScheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-a5bb11155d95772aa731dcd231698b1e33bcce07682dcc64948564fa2a876577">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ThemeProviderObserveSystemDarkModeChangeTest.razor</strong><dd><code>Update test component to use ColorScheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-b2dce667de0d92c6649d0fa5c969ae6637fee7513532523881a92b4f40d0862e">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Overview.razor</strong><dd><code>Update documentation to reference ColorScheme</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-d459059f89082c8957bc8e45788136a40978399f83051add8c8083a09f6f62a3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>ColorSchemeTests.cs</strong><dd><code>Add comprehensive ColorScheme enum tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-fdbdf7d768c02f9e7c5b9ca5d2bfe9e113a46e1cda4f912b265e5e34161f80f0">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ThemeProviderTests.cs</strong><dd><code>Update tests for ColorScheme and add pragma directives</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-44061d55043a22ebab06110d080c244cf000a58608adf127843e7da4b9fe1f6b">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Update sass dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/25/files#diff-cc5a2f170768969f124108ad3be7fdbcbed774c11774d99a87a3a78fef4ab97b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced ColorScheme (Light/Dark/System) as primary theme control; UI toggles and notifications now reflect color-scheme state and resolved dark-mode changes.
* **Documentation**
  * Theme docs and examples updated to show ColorScheme usage and system-preference behavior.
* **Tests**
  * Added tests validating ColorScheme behaviors, system resolution, and runtime switching.
* **Chores**
  * Bumped Sass dependency to v1.97.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->