### PR TITLE
Implement per-snackbar position override

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SnackbarPositionTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarPositionTests.cs
@@ -1,0 +1,95 @@
+using AwesomeAssertions;
+using Bunit;
+using MudBlazor.UnitTests.TestComponents.Snackbar;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    [NonParallelizable]
+    public class SnackbarPositionTests : BunitTest
+    {
+        private IRenderedComponent<MudSnackbarProvider> _provider;
+        private ISnackbar _service;
+
+        [SetUp]
+        public void SnackbarSetUp()
+        {
+            _service = Context.Services.GetService<ISnackbar>();
+            _provider = Context.Render<MudSnackbarProvider>();
+        }
+
+        [TearDown]
+        public async Task SnackbarTearDown()
+        {
+            await _provider.InvokeAsync(() => _service.Clear());
+        }
+
+        [Test]
+        public async Task PerSnackbarPosition()
+        {
+            _service.Configuration.PositionClass = Defaults.Classes.Position.TopRight;
+
+            await _provider.InvokeAsync(() => _service.Add("Default position"));
+            await _provider.InvokeAsync(() => _service.Add("Custom position", Severity.Info, config =>
+            {
+                config.PositionClass = Defaults.Classes.Position.BottomLeft;
+            }));
+
+            // We should now have two containers.
+            var containers = _provider.FindAll(".mud-snackbar-container");
+            containers.Count.Should().Be(2);
+
+            var topRightContainer = containers.FirstOrDefault(c => c.ClassName.Contains(Defaults.Classes.Position.TopRight));
+            topRightContainer.Should().NotBeNull();
+            topRightContainer.InnerHtml.Should().Contain("Default position");
+
+            var bottomLeftContainer = containers.FirstOrDefault(c => c.ClassName.Contains(Defaults.Classes.Position.BottomLeft));
+            bottomLeftContainer.Should().NotBeNull();
+            bottomLeftContainer.InnerHtml.Should().Contain("Custom position");
+        }
+
+        [Test]
+        public async Task PerSnackbarPositionDynamicFallback()
+        {
+            _service.Configuration.PositionClass = Defaults.Classes.Position.TopRight;
+
+            await _provider.InvokeAsync(() => _service.Add("Follows global"));
+
+            var containers = _provider.FindAll(".mud-snackbar-container");
+            containers.Count.Should().Be(1);
+            containers[0].ClassName.Should().Contain(Defaults.Classes.Position.TopRight);
+
+            // Change global position
+            await _provider.InvokeAsync(() => _service.Configuration.PositionClass = Defaults.Classes.Position.BottomRight);
+
+            containers = _provider.FindAll(".mud-snackbar-container");
+            containers.Count.Should().Be(1);
+            containers[0].ClassName.Should().Contain(Defaults.Classes.Position.BottomRight);
+            containers[0].InnerHtml.Should().Contain("Follows global");
+        }
+
+        [Test]
+        public async Task PerSnackbarPositionNoDynamicFallbackIfOverridden()
+        {
+            _service.Configuration.PositionClass = Defaults.Classes.Position.TopRight;
+
+            await _provider.InvokeAsync(() => _service.Add("Overridden", Severity.Success, config =>
+            {
+                config.PositionClass = Defaults.Classes.Position.BottomLeft;
+            }));
+
+            var containers = _provider.FindAll(".mud-snackbar-container");
+            containers.Count.Should().Be(1);
+            containers[0].ClassName.Should().Contain(Defaults.Classes.Position.BottomLeft);
+
+            // Change global position - should not affect the overridden snackbar
+            await _provider.InvokeAsync(() => _service.Configuration.PositionClass = Defaults.Classes.Position.TopCenter);
+
+            // We still have the BottomLeft container because the snackbar is still there
+            containers = _provider.FindAll(".mud-snackbar-container");
+            containers.Count.Should().Be(1);
+            containers[0].ClassName.Should().Contain(Defaults.Classes.Position.BottomLeft);
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SnackbarTests.cs
@@ -20,7 +20,7 @@ namespace MudBlazor.UnitTests.Components
         {
             _service = Context.Services.GetService<ISnackbar>();
             _provider = Context.Render<MudSnackbarProvider>();
-            _provider.Find("#mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
+            _provider.Find(".mud-snackbar-container").InnerHtml.Trimmed().Should().BeEmpty();
         }
 
         [TearDown]
@@ -34,7 +34,7 @@ namespace MudBlazor.UnitTests.Components
         public async Task Simple()
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
-            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find(".mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
         }
 
@@ -48,7 +48,7 @@ namespace MudBlazor.UnitTests.Components
             });
 
             await _provider.InvokeAsync(() => _service.Add(renderFragment));
-            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find(".mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be(testText);
         }
 
@@ -82,7 +82,7 @@ namespace MudBlazor.UnitTests.Components
             });
             // shoot out a snackbar
             await _provider.InvokeAsync(() => _service.Add(renderFragment));
-            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find(".mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             _provider.Find("div.mud-snackbar-content-message").InnerHtml.Should().Be($"<ul><li>{testText}</li></ul>");
         }
 
@@ -238,7 +238,7 @@ namespace MudBlazor.UnitTests.Components
                 _provider.Find("div.mud-snackbar-content-message").Should().NotBe(null)
             );
 
-            var svg = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild;
+            var svg = _provider.Find(".mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild;
             svg.ClassName.Should().Contain("mud-icon-size-large");
             svg.InnerHtml.Should().Contain("M15.73,3H8.27L3,8.27v7.46L8.27,21h7.46L21,15.73V8.27L15.73,3z M19,14.9L14.9,19H9.1L5,14.9V9.1L9.1,5h5.8L19,9.1V14.9z");
         }
@@ -247,14 +247,14 @@ namespace MudBlazor.UnitTests.Components
         public async Task Icon()
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!"));
-            _provider.Find("#mud-snackbar-container .mud-snackbar .mud-snackbar-icon").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find(".mud-snackbar-container .mud-snackbar .mud-snackbar-icon").InnerHtml.Trim().Should().NotBeEmpty();
         }
 
         [Test]
         public async Task HideIcon()
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.HideIcon = true; }));
-            var hasIcon = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.ClassName.Contains("mud-snackbar-icon");
+            var hasIcon = _provider.Find(".mud-snackbar-container .mud-snackbar").FirstElementChild.ClassName.Contains("mud-snackbar-icon");
             hasIcon.Should().BeFalse();
         }
 
@@ -263,7 +263,7 @@ namespace MudBlazor.UnitTests.Components
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success, config => { config.IconColor = Color.Tertiary; config.IconSize = Size.Large; }));
 
-            var svgClassNames = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
+            var svgClassNames = _provider.Find(".mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
             svgClassNames.Should().Contain("mud-icon-size-large");
             svgClassNames.Should().Contain("mud-tertiary-text");
         }
@@ -273,7 +273,7 @@ namespace MudBlazor.UnitTests.Components
         {
             await _provider.InvokeAsync(() => _service.Add("Boom, big reveal. Im a pickle!", Severity.Success));
 
-            var svgClassNames = _provider.Find("#mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
+            var svgClassNames = _provider.Find(".mud-snackbar-container .mud-snackbar").FirstElementChild.FirstElementChild.ClassName;
             svgClassNames.Should().Contain("mud-icon-size-medium");
 
             // Ensure no color classes are present, like "mud-primary-text", "mud-error-text", etc.
@@ -313,7 +313,7 @@ namespace MudBlazor.UnitTests.Components
 
             snackbar?.Dispose();
 
-            _provider.Find("#mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
+            _provider.Find(".mud-snackbar-container").InnerHtml.Trim().Should().NotBeEmpty();
             _provider.Find("div.mud-snackbar-content-message").TrimmedText().Should().Be("Boom, big reveal. Im a pickle!");
         }
 

--- a/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs
@@ -130,6 +130,14 @@ public abstract class CommonSnackbarOptions
     /// </remarks>
     public bool HideIcon { get; set; }
 
+    /// <summary>
+    /// The CSS classes used to position the snackbar.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    public string? PositionClass { get; set; }
+
     protected CommonSnackbarOptions() { }
 
     protected CommonSnackbarOptions(CommonSnackbarOptions options)
@@ -149,5 +157,6 @@ public abstract class CommonSnackbarOptions
         WarningIcon = options.WarningIcon;
         ErrorIcon = options.ErrorIcon;
         HideIcon = options.HideIcon;
+        PositionClass = options.PositionClass;
     }
 }

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor
@@ -7,11 +7,21 @@
 @inherits MudComponentBase
 
 @{
-}
-
-<div @attributes="UserAttributes" id="mud-snackbar-container" class="@Classname" style="@Style">
-    @foreach (var snackbar in Snackbar)
+    var groups = GroupedSnackbars.ToList();
+    if (!groups.Any())
     {
-        <MudSnackbarElement @key="snackbar" Snackbar="@snackbar"></MudSnackbarElement>
+        <div @attributes="UserAttributes" class="@GetContainerClass(Snackbars.Configuration.PositionClass)" style="@Style"></div>
     }
-</div>
+    else
+    {
+        @foreach (var group in groups)
+        {
+            <div @attributes="UserAttributes" class="@GetContainerClass(group.Key)" style="@Style">
+                @foreach (var snackbar in group)
+                {
+                    <MudSnackbarElement @key="snackbar" Snackbar="@snackbar"></MudSnackbarElement>
+                }
+            </div>
+        }
+    }
+}

--- a/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
+++ b/src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs
@@ -19,18 +19,26 @@ namespace MudBlazor
         [CascadingParameter(Name = "RightToLeft")]
         public bool RightToLeft { get; set; }
 
-        protected IEnumerable<Snackbar> Snackbar => Snackbars.Configuration.NewestOnTop
-                ? Snackbars.ShownSnackbars.Reverse()
-                : Snackbars.ShownSnackbars;
+        protected IEnumerable<IGrouping<string, Snackbar>> GroupedSnackbars
+        {
+            get
+            {
+                var snackbars = Snackbars.Configuration.NewestOnTop
+                    ? Snackbars.ShownSnackbars.Reverse()
+                    : Snackbars.ShownSnackbars;
 
-        protected string Classname =>
-            new CssBuilder(Class)
-                .AddClass(GetPositionClass())
+                return snackbars.GroupBy(s => s.State.Options.PositionClass ?? Snackbars.Configuration.PositionClass);
+            }
+        }
+
+        protected string GetContainerClass(string positionClass) =>
+            new CssBuilder("mud-snackbar-container")
+                .AddClass(GetPositionClass(positionClass))
+                .AddClass(Class)
                 .Build();
 
-        private string GetPositionClass()
+        private string GetPositionClass(string positionClass)
         {
-            var positionClass = Snackbars.Configuration.PositionClass;
             return positionClass switch
             {
                 Defaults.Classes.Position.BottomStart => RightToLeft ? Defaults.Classes.Position.BottomRight : Defaults.Classes.Position.BottomLeft,

--- a/src/MudBlazor/Components/Snackbar/SnackbarConfiguration.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarConfiguration.cs
@@ -8,7 +8,6 @@ namespace MudBlazor
         private bool _newestOnTop;
         private bool _preventDuplicates;
         private int _maxDisplayedSnackbars;
-        private string _positionClass = string.Empty;
         private bool _clearAfterNavigation;
 
         internal event Action? OnUpdate;
@@ -43,12 +42,18 @@ namespace MudBlazor
             }
         }
 
-        public string PositionClass
+        /// <summary>
+        /// The CSS classes used to position the snackbar.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Defaults.Classes.Position.TopRight"/>.
+        /// </remarks>
+        public new string PositionClass
         {
-            get => _positionClass;
+            get => base.PositionClass ?? Defaults.Classes.Position.TopRight;
             set
             {
-                _positionClass = value;
+                base.PositionClass = value;
                 OnUpdate?.Invoke();
             }
         }

--- a/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
+++ b/src/MudBlazor/Components/Snackbar/SnackbarOptions.cs
@@ -101,6 +101,7 @@ namespace MudBlazor
         public SnackbarOptions(Severity severity, CommonSnackbarOptions options) : base(options)
         {
             Severity = severity;
+            PositionClass = null;
 
             if (string.IsNullOrEmpty(Icon))
             {

--- a/src/MudBlazor/Styles/components/_snackbar.scss
+++ b/src/MudBlazor/Styles/components/_snackbar.scss
@@ -90,7 +90,7 @@
   }
 }
 
-#mud-snackbar-container {
+.mud-snackbar-container {
   position: fixed;
   z-index: var(--mud-zindex-snackbar);
   pointer-events: none


### PR DESCRIPTION
### **User description**
Implemented the ability to override the snackbar position for individual snackbars.
- Moved PositionClass to CommonSnackbarOptions.
- Updated SnackbarConfiguration to maintain its global default and update trigger.
- Updated SnackbarOptions to support null (dynamic fallback) or explicit override.
- Modified MudSnackbarProvider to group snackbars by position and render multiple containers.
- Changed snackbar container selector from ID (#mud-snackbar-container) to class (.mud-snackbar-container) to support multiple containers.
- Added comprehensive unit tests and verified with visual test viewer.

---
*PR created automatically by Jules for task [4019392281122205405](https://jules.google.com/task/4019392281122205405) started by @Anu6is*


___

### **PR Type**
Enhancement


___

### **Description**
- Enable per-snackbar position override capability

- Move PositionClass to CommonSnackbarOptions for inheritance

- Group snackbars by position and render multiple containers

- Update container selector from ID to class for multiple instances

- Add comprehensive unit tests for position override functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SnackbarConfiguration<br/>PositionClass"] -->|inherits| B["CommonSnackbarOptions<br/>PositionClass property"]
  B -->|used by| C["SnackbarOptions<br/>null for dynamic fallback"]
  C -->|grouped by| D["MudSnackbarProvider<br/>GroupedSnackbars"]
  D -->|renders| E["Multiple containers<br/>.mud-snackbar-container"]
  F["Snackbar.Add<br/>with config override"] -->|sets| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SnackbarPositionTests.cs</strong><dd><code>Add comprehensive snackbar position override tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor.UnitTests/Components/SnackbarPositionTests.cs

<ul><li>New test file with three comprehensive test cases<br> <li> PerSnackbarPosition: verifies multiple containers for different <br>positions<br> <li> PerSnackbarPositionDynamicFallback: tests null position follows global <br>config changes<br> <li> PerSnackbarPositionNoDynamicFallbackIfOverridden: confirms overridden <br>positions are static</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-d3f62fe63b642bb4379c7b6b8fb3aeea49c8f6c7db2b4ef7a9c4e5d3a50dc88f">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SnackbarTests.cs</strong><dd><code>Update container selectors to class-based approach</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor.UnitTests/Components/SnackbarTests.cs

<ul><li>Update all container selectors from ID-based to class-based<br> <li> Change <code>#mud-snackbar-container</code> to <code>.mud-snackbar-container</code> across 11 <br>test assertions<br> <li> Maintains existing test logic and expectations</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-7ecba239eb6a6bbd98dac1f3843663c32a57d1a66ada866943338c6708f2417f">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommonSnackbarOptions.cs</strong><dd><code>Add PositionClass property to base options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/Snackbar/CommonSnackbarOptions.cs

<ul><li>Add PositionClass property with null default and documentation<br> <li> Include PositionClass in copy constructor for proper inheritance<br> <li> Property supports null for dynamic fallback behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-8a0d38b36712acfea99ffcbfa82b29e596e707f1a3c2a1f2ac876876c6e8abed">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SnackbarConfiguration.cs</strong><dd><code>Refactor PositionClass to use base property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/Snackbar/SnackbarConfiguration.cs

<ul><li>Remove private <code>_positionClass</code> field backing store<br> <li> Override PositionClass property to use base class with TopRight <br>default<br> <li> Trigger OnUpdate event when position changes<br> <li> Add XML documentation for PositionClass property</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-011010e6bbc5d3a13da441d5b62e9db9d6f9a3c8dbf25eed6c84b336e0f36dee">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SnackbarOptions.cs</strong><dd><code>Set PositionClass to null for dynamic fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/Snackbar/SnackbarOptions.cs

<ul><li>Initialize PositionClass to null in constructor for dynamic fallback<br> <li> Allows individual snackbars to inherit global position when not <br>overridden</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-aef773b700fe179c19e392393fcf75c2ba2703e8b20a7c5b98ce7db89b465699">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MudSnackbarProvider.razor.cs</strong><dd><code>Implement snackbar grouping by position</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor.cs

<ul><li>Replace Snackbar property with GroupedSnackbars that groups by <br>position<br> <li> Implement GetContainerClass method accepting positionClass parameter<br> <li> Add logic to fall back to global configuration when position is null<br> <li> Support multiple containers with different position classes</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-96dd656c3e988a194e652e245bbf434b28a5c95e12061feb62092f6019cd5102">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MudSnackbarProvider.razor</strong><dd><code>Render multiple containers per position group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Components/Snackbar/MudSnackbarProvider.razor

<ul><li>Render multiple container divs grouped by position instead of single <br>container<br> <li> Add conditional rendering for empty snackbar state<br> <li> Apply GetContainerClass method to each container group<br> <li> Iterate through grouped snackbars for rendering</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-31fd04597db65bf06c61fa8bc47288c7ecfd593233e868b7d529f9ceea8c2fcf">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_snackbar.scss</strong><dd><code>Update container selector to class-based</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/MudBlazor/Styles/components/_snackbar.scss

<ul><li>Change selector from ID <code>#mud-snackbar-container</code> to class <br><code>.mud-snackbar-container</code><br> <li> Enables CSS styling for multiple container instances</ul>


</details>


  </td>
  <td><a href="https://github.com/Anu6is/MudBlazor/pull/27/files#diff-b64a59c5ea1d50b83d92c393ecf893e20edc0c6abcde8d23c07b443ea3ebf627">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-snackbar position customization, allowing individual snackbars to override global position settings and display at different screen locations simultaneously.

* **Tests**
  * Added comprehensive unit tests verifying per-snackbar position behavior, dynamic fallback, and override scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->