### PR TITLE
Limit radial chart legend to visible items

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartTests.cs
@@ -734,5 +734,75 @@ namespace MudBlazor.UnitTests.Components
             yaxis.Should().NotBeNull();
             yaxis[0].Children[0].InnerHtml.Trim().Should().Be(testCase.ExpectedValue);
         }
+
+        [Test]
+        public void PieChart_LegendShouldOnlyShowVisibleItems()
+        {
+            var labels = new[] { "A", "B", "C", "D", "E" };
+            var data = new double[] { 10, 20, 30 }; // 3 data points, 5 labels
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.ChartSeries, data.AsChartDataSet())
+                .Add(p => p.ChartLabels, labels)
+            );
+
+            var legendItems = comp.FindAll(".mud-chart-legend-item");
+            legendItems.Count.Should().Be(3);
+            legendItems[0].TextContent.Trim().Should().Be("A");
+            legendItems[1].TextContent.Trim().Should().Be("B");
+            legendItems[2].TextContent.Trim().Should().Be("C");
+        }
+
+        [Test]
+        public void PieChart_LegendShouldIncludeZeroValues()
+        {
+            var labels = new[] { "A", "B", "C" };
+            var data = new double[] { 10, 0, 30 }; // Zero value in the middle
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.ChartSeries, data.AsChartDataSet())
+                .Add(p => p.ChartLabels, labels)
+            );
+
+            var legendItems = comp.FindAll(".mud-chart-legend-item");
+            legendItems.Count.Should().Be(3);
+            legendItems[1].TextContent.Trim().Should().Be("B");
+        }
+
+        [Test]
+        public async Task PieChart_LegendShouldUpdateWhenSeriesVisibilityChanges()
+        {
+            var labels = new[] { "A", "B", "C", "D" };
+            var series1 = new ChartSeries<double> { Name = "S1", Data = new double[] { 10, 20, 30 }, Visible = true };
+            var series2 = new ChartSeries<double> { Name = "S2", Data = new double[] { 10, 20, 30, 40 }, Visible = false };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Pie)
+                .Add(p => p.ChartSeries, new List<ChartSeries<double>> { series1, series2 })
+                .Add(p => p.ChartLabels, labels)
+            );
+
+            // Initially only series1 is visible, so 3 legend items
+            var legendItems = comp.FindAll(".mud-chart-legend-item");
+            legendItems.Count.Should().Be(3);
+
+            // Make series2 visible
+            series2.Visible = true;
+            comp.Instance.RebuildChart(); // Ensure rebuild
+            comp.Render();
+
+            legendItems = comp.FindAll(".mud-chart-legend-item");
+            legendItems.Count.Should().Be(4);
+
+            // Hide series1
+            series1.Visible = false;
+            comp.Instance.RebuildChart();
+            comp.Render();
+
+            legendItems = comp.FindAll(".mud-chart-legend-item");
+            legendItems.Count.Should().Be(4); // Series 2 is still visible and has 4 items
+        }
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RoseChartTests.cs
@@ -277,7 +277,7 @@ public class RoseChartTests : BunitTest
 
         // Check legend items
         var legendItems = comp.FindAll(".mud-chart-legend-item");
-        legendItems.Count.Should().Be(3);
+        legendItems.Count.Should().Be(2);
     }
 
     [Test]

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -197,7 +197,9 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
     /// <param name="chartLabels">The labels for the chart.</param>
     protected void BuildLegends(string[] chartLabels)
     {
-        for (var i = 0; i < chartLabels.Length; i++)
+        var actualDataLength = GetActualDataLength();
+        var legendCount = Math.Min(chartLabels.Length, actualDataLength);
+        for (var i = 0; i < legendCount; i++)
         {
             var label = chartLabels[i];
 
@@ -214,6 +216,22 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
                 OnVisibilityChanged = EventCallback.Factory.Create<SvgLegend>(this, HandleLegendVisibilityChanged)
             });
         }
+    }
+
+    private int GetActualDataLength()
+    {
+        if (ChartSeries == null || ChartSeries.Count == 0)
+        {
+            return 0;
+        }
+
+        if (ChartOptions!.AggregationOption == AggregationOption.GroupByDataSet)
+        {
+            return ChartSeries.Count;
+        }
+
+        return ChartSeries.Where(s => s.Visible).DefaultIfEmpty()
+            .Max(s => s?.Data?.Values?.Count ?? 0);
     }
 
     /// <summary>


### PR DESCRIPTION
This change fixes a bug where radial charts (Pie, Donut, Rose) would display all legend items for every label provided, even if the data series only contained a few points. The fix ensures that the legend only shows items that have corresponding data in the currently visible series. Zero-value data points are still included in the legend if they are within the data range, as per user requirement.

---
*PR created automatically by Jules for task [17716653323016589042](https://jules.google.com/task/17716653323016589042) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chart legends in Pie and Rose charts to display only items corresponding to available data, preventing misalignment between legend entries and actual data points.

* **Tests**
  * Added unit tests for Pie chart legend rendering with visibility changes and zero-valued data points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->