### PR TITLE
Add horizontal expansion to MudCollapse

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Collapse/CollapsePage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Collapse/CollapsePage.razor
@@ -13,5 +13,14 @@
             </SectionContent>
         </DocsPageSection>
 
+        <DocsPageSection>
+            <SectionHeader Title="Direction">
+                <Description>The <CodeInline>Direction</CodeInline> property allows you to control the direction in which the content expands. Support for horizontal expansion is included by using <CodeInline>Direction.Left</CodeInline>, <CodeInline>Direction.Right</CodeInline>, <CodeInline>Direction.Start</CodeInline>, or <CodeInline>Direction.End</CodeInline>.</Description>
+            </SectionHeader>
+            <SectionContent DarkenBackground="true" Code="@nameof(CollapseDirectionExample)">
+                <CollapseDirectionExample />
+            </SectionContent>
+        </DocsPageSection>
+
     </DocsPageContent>
 </DocsPage>

--- a/src/MudBlazor.Docs/Pages/Components/Collapse/Examples/CollapseDirectionExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Collapse/Examples/CollapseDirectionExample.razor
@@ -1,0 +1,30 @@
+@namespace MudBlazor.Docs.Examples
+
+<MudPaper Class="pa-4">
+    <MudStack>
+        <MudStack Row="true" AlignItems="AlignItems.Center">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@(() => _expanded = !_expanded)">@(_expanded ? "Collapse All" : "Expand All")</MudButton>
+            <MudSelect T="Direction" Label="Direction" @bind-Value="_direction" Dense="true" Style="width: 200px;">
+                @foreach (Direction item in Enum.GetValues(typeof(Direction)))
+                {
+                    <MudSelectItem Value="@item">@item</MudSelectItem>
+                }
+            </MudSelect>
+        </MudStack>
+
+        <MudDivider />
+
+        <div class="d-flex justify-center align-center" style="height: 300px; border: 1px dashed var(--mud-palette-divider); overflow: hidden;">
+            <MudCollapse Expanded="_expanded" Direction="_direction">
+                <MudPaper Class="pa-8 mud-theme-primary">
+                    <MudText>Expanding towards @_direction</MudText>
+                </MudPaper>
+            </MudCollapse>
+        </div>
+    </MudStack>
+</MudPaper>
+
+@code {
+    bool _expanded = true;
+    Direction _direction = Direction.Bottom;
+}

--- a/src/MudBlazor.UnitTests/Components/CollapseHorizontalTests.cs
+++ b/src/MudBlazor.UnitTests/Components/CollapseHorizontalTests.cs
@@ -1,0 +1,63 @@
+using AwesomeAssertions;
+using Bunit;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class CollapseHorizontalTests : BunitTest
+    {
+        [Test]
+        public void Collapse_Horizontal_Direction_Classes()
+        {
+            var comp = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.Direction, Direction.Right));
+
+            comp.Find(".mud-collapse-container").ClassList.Should().Contain("mud-collapse-horizontal");
+            comp.Find(".mud-collapse-container").ClassList.Should().Contain("mud-collapse-direction-right");
+        }
+
+        [Test]
+        public void Collapse_Vertical_Direction_Classes()
+        {
+            var comp = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.Direction, Direction.Top));
+
+            comp.Find(".mud-collapse-container").ClassList.Should().NotContain("mud-collapse-horizontal");
+            comp.Find(".mud-collapse-container").ClassList.Should().Contain("mud-collapse-direction-top");
+        }
+
+        [Test]
+        public void Collapse_MaxWidth_Style()
+        {
+            var comp = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.MaxWidth, 500));
+
+            comp.Find(".mud-collapse-container").GetAttribute("style").Should().Contain("max-width:500px");
+        }
+
+        [Test]
+        public void Collapse_IsHorizontal_Start_End()
+        {
+            var compStart = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.Direction, Direction.Start));
+            compStart.Find(".mud-collapse-container").ClassList.Should().Contain("mud-collapse-horizontal");
+
+            var compEnd = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.Direction, Direction.End));
+            compEnd.Find(".mud-collapse-container").ClassList.Should().Contain("mud-collapse-horizontal");
+        }
+
+        [Test]
+        public void Collapse_Both_Max_Styles()
+        {
+            var comp = Context.Render<MudCollapse>(parameters => parameters
+                .Add(p => p.MaxHeight, 300)
+                .Add(p => p.MaxWidth, 500));
+
+            var style = comp.Find(".mud-collapse-container").GetAttribute("style");
+            style.Should().Contain("max-height:300px");
+            style.Should().Contain("max-width:500px");
+        }
+    }
+}

--- a/src/MudBlazor/Attributes/CategoryAttribute.cs
+++ b/src/MudBlazor/Attributes/CategoryAttribute.cs
@@ -225,6 +225,12 @@ namespace MudBlazor
             public const string Appearance = "Appearance";
         }
 
+        public static class Collapse
+        {
+            public const string Behavior = "Behavior";
+            public const string Appearance = "Appearance";
+        }
+
         public static class Chip
         {
             public const string Behavior = "Behavior";

--- a/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
+++ b/src/MudBlazor/Components/Collapse/MudCollapse.razor.cs
@@ -24,13 +24,18 @@ namespace MudBlazor
             .AddClass("mud-collapse-entered", _state == CollapseState.Entered)
             .AddClass("mud-collapse-exiting", _state == CollapseState.Exiting)
             .AddClass("invisible", _state == CollapseState.Exited)
+            .AddClass("mud-collapse-horizontal", IsHorizontal)
+            .AddClass($"mud-collapse-direction-{Direction.ToStringFast(true)}")
             .AddClass(Class)
             .Build();
 
         protected string Stylename => new StyleBuilder()
             .AddStyle("max-height", MaxHeight.ToPx(), MaxHeight != null)
+            .AddStyle("max-width", MaxWidth.ToPx(), MaxWidth != null)
             .AddStyle(Style)
             .Build();
+
+        private bool IsHorizontal => Direction is Direction.Left or Direction.Right or Direction.Start or Direction.End;
 
         /// <summary>
         /// Displays content within this panel.
@@ -39,7 +44,18 @@ namespace MudBlazor
         /// Defaults to <c>false</c>.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Collapse.Behavior)]
         public bool Expanded { get; set; }
+
+        /// <summary>
+        /// The direction the panel expands.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="Direction.Bottom"/>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Collapse.Appearance)]
+        public Direction Direction { get; set; } = Direction.Bottom;
 
         /// <summary>
         /// The maximum allowed height of this panel, in pixels.
@@ -48,24 +64,38 @@ namespace MudBlazor
         /// Defaults to <c>null</c>.
         /// </remarks>
         [Parameter]
+        [Category(CategoryTypes.Collapse.Appearance)]
         public int? MaxHeight { get; set; }
+
+        /// <summary>
+        /// The maximum allowed width of this panel, in pixels.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>null</c>.
+        /// </remarks>
+        [Parameter]
+        [Category(CategoryTypes.Collapse.Appearance)]
+        public int? MaxWidth { get; set; }
 
         /// <summary>
         /// The content within this panel.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Collapse.Behavior)]
         public RenderFragment? ChildContent { get; set; }
 
         /// <summary>
         /// Occurs when the collapse or expand animation has finished.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Collapse.Behavior)]
         public EventCallback OnAnimationEnd { get; set; }
 
         /// <summary>
         /// Occurs when the <see cref="Expanded"/> property has changed.
         /// </summary>
         [Parameter]
+        [Category(CategoryTypes.Collapse.Behavior)]
         public EventCallback<bool> ExpandedChanged { get; set; }
 
         public MudCollapse()

--- a/src/MudBlazor/Styles/components/_collapse.scss
+++ b/src/MudBlazor/Styles/components/_collapse.scss
@@ -3,18 +3,39 @@
   display: grid;
   grid-template-rows: minmax(0, 0fr);
   transition: grid-template-rows 300ms ease-in-out;
+
+  &.mud-collapse-horizontal {
+    width: fit-content;
+    grid-template-rows: initial;
+    grid-template-columns: minmax(0, 0fr);
+    transition: grid-template-columns 300ms ease-in-out;
+  }
 }
 
 .mud-collapse-entering {
   grid-template-rows: minmax(0, 1fr);
+
+  &.mud-collapse-horizontal {
+    grid-template-rows: initial;
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .mud-collapse-entered {
   overflow: initial;
   grid-template-rows: minmax(0, 1fr);
 
+  &.mud-collapse-horizontal {
+    grid-template-rows: initial;
+    grid-template-columns: minmax(0, 1fr);
+
+    & .mud-collapse-wrapper {
+      overflow-x: auto;
+    }
+  }
+
   & .mud-collapse-wrapper {
-      overflow-y: auto;
+    overflow-y: auto;
   }
 }
 
@@ -29,4 +50,16 @@
 
 .mud-collapse-wrapper-inner {
   width: 100%;
+}
+
+.mud-collapse-direction-top {
+  margin-top: auto;
+}
+
+.mud-collapse-direction-left {
+  margin-left: auto;
+}
+
+.mud-collapse-direction-start {
+  margin-inline-start: auto;
 }


### PR DESCRIPTION
This change adds support for horizontal expansion to the MudCollapse component. It introduces a `Direction` parameter that allows the component to expand in any direction (Top, Bottom, Left, Right, Start, End). It also adds a `MaxWidth` parameter to control the width during horizontal expansion. The implementation uses CSS Grid to ensure smooth animations and `margin: auto` for proper anchoring. Unit tests and documentation examples are included.

---
*PR created automatically by Jules for task [3671104407453215865](https://jules.google.com/task/3671104407453215865) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collapse component now supports directional collapsing with a new Direction parameter (Bottom, Top, Left, Right, Start, End).
  * Added MaxWidth parameter for controlling horizontal collapse dimensions.
  * Added OnAnimationEnd event callback to detect animation completion.

* **Tests**
  * Added comprehensive unit tests for horizontal collapse behavior and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->