### PR TITLE
Remove experimental warning from Heat Map component

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor
@@ -3,19 +3,7 @@
 @page "/components/chart-types/heatmapchart"
 
 <DocsPage>
-    <DocsPageHeader Title="HeatMap Chart" SubTitle="A chart that displays a HeatMap" Component="@nameof(MudBlazor.Charts.HeatMap<T>)">
-        <Description>
-            <DocsPageSection>
-                <MudAlert Class="mt-4" Severity="Severity.Warning">
-                    <b>Warning:</b> This component is currently under development.
-                    <br />
-                    <br />
-                    Breaking changes such as updates to the API, look and feel, or CSS classes, may occur even in minor patch releases.
-                    Please use it only if you are prepared to adapt your code accordingly and provide feedback or contribute code.
-                </MudAlert>
-            </DocsPageSection>
-        </Description>
-    </DocsPageHeader>
+    <DocsPageHeader Title="HeatMap Chart" SubTitle="A chart that displays a HeatMap" Component="@nameof(MudBlazor.Charts.HeatMap<T>)" />
     <DocsPageContent>
 
         <DocsPageSection>


### PR DESCRIPTION
Removed the experimental warning alert from the HeatMap Chart documentation page (`src/MudBlazor.Docs/Pages/Components/Charts/HeatMapChartPage.razor`). The component is no longer considered experimental/under development. Verified the change visually by running the documentation server and taking a screenshot with Playwright.

---
*PR created automatically by Jules for task [9971235978750046792](https://jules.google.com/task/9971235978750046792) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Heat Map Chart documentation page by removing warning information and descriptive content from the header section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->