### PR TITLE
Fix MudChart infinite expansion loop with MatchBoundsToSize and relative height

### DIFF
--- a/src/MudBlazor.UnitTests/Components/ChartMatchBoundsToSizeTests.cs
+++ b/src/MudBlazor.UnitTests/Components/ChartMatchBoundsToSizeTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using AngleSharp.Dom;
+using AwesomeAssertions;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using MudBlazor.Charts;
+using MudBlazor.Interop;
+using MudBlazor.UnitTests.Shared;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class ChartMatchBoundsToSizeTests : BunitTest
+    {
+        [Test]
+        public async Task MatchBoundsToSize_WithPercentageHeight_ShouldNotLoop()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Data = new double[] { 12.2, 14.3, 11.5 } }
+            };
+            var labels = new[] { "1/1/26", "2/1/26", "3/1/26" };
+
+            var initialSize = new ElementSize { Width = 700, Height = 350, Timestamp = 1 };
+
+            Context.JSInterop.Setup<ElementSize>("mudObserveElementSize", _ => true)
+                .SetResult(initialSize);
+
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ => true)
+                .SetResult(new ElementSize { Width = 50, Height = 20 });
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, series)
+                .Add(p => p.ChartLabels, labels)
+                .Add(p => p.MatchBoundsToSize, true)
+                .Add(p => p.Width, "100%")
+                .Add(p => p.Height, "80%")
+            );
+
+            var chartBase = comp.FindComponent<Line<double>>().Instance;
+
+            var svg = comp.Find("svg");
+            svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+
+            var largerSize = new ElementSize { Width = 700, Height = 400, Timestamp = 2 };
+
+            await comp.InvokeAsync(() => chartBase.OnElementSizeChanged(largerSize));
+
+            await Task.Delay(300);
+
+            svg = comp.Find("svg");
+            // CURRENT BEHAVIOR: It updates to 400.
+            // EXPECTED BEHAVIOR after fix: It should stay at 350 (or whatever it was initially set to when parsing Height/Width)
+            // because Height is percentage.
+            svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+        }
+
+        [Test]
+        public async Task MatchBoundsToSize_WithPixelHeight_ShouldUpdate()
+        {
+            var series = new List<ChartSeries<double>>
+            {
+                new() { Data = new double[] { 12.2, 14.3, 11.5 } }
+            };
+            var labels = new[] { "1/1/26", "2/1/26", "3/1/26" };
+
+            var initialSize = new ElementSize { Width = 700, Height = 350, Timestamp = 1 };
+
+            Context.JSInterop.Setup<ElementSize>("mudObserveElementSize", _ => true)
+                .SetResult(initialSize);
+
+            Context.JSInterop.Setup<ElementSize>("mudGetSvgBBox", _ => true)
+                .SetResult(new ElementSize { Width = 50, Height = 20 });
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Line)
+                .Add(p => p.ChartSeries, series)
+                .Add(p => p.ChartLabels, labels)
+                .Add(p => p.MatchBoundsToSize, true)
+                .Add(p => p.Width, "700px")
+                .Add(p => p.Height, "350px")
+            );
+
+            var chartBase = comp.FindComponent<Line<double>>().Instance;
+
+            var svg = comp.Find("svg");
+            svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
+
+            var largerSize = new ElementSize { Width = 800, Height = 400, Timestamp = 2 };
+
+            await comp.InvokeAsync(() => chartBase.OnElementSizeChanged(largerSize));
+
+            await Task.Delay(300);
+
+            svg = comp.Find("svg");
+            svg.GetAttribute("viewBox").Should().Be("0 0 800 400");
+        }
+    }
+}

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -227,18 +227,32 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
 
         if (MatchBoundsToSize)
         {
+            var isWidthFixed = Width.EndsWith("px");
+            var isHeightFixed = Height.EndsWith("px");
+
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                // If the width/height is not fixed (e.g., percentage or auto), we use the default for the bounds
+                // if the element size is 0 or if we want to prevent expansion loops.
+                // For width, we generally trust the observed size as it rarely loops horizontally in standard layouts.
+                _boundWidth = _elementSize.Width > 0 ? _elementSize.Width : BoundWidthDefault;
+
+                // For height, if it's not fixed, we use the default height to prevent a continuous expansion loop
+                // that can occur when the chart content determines the parent's height.
+                _boundHeight = isHeightFixed ? _elementSize.Height : BoundHeightDefault;
             }
-            else if (Width.EndsWith("px")
-                && Height.EndsWith("px")
+            else if (isWidthFixed
+                && isHeightFixed
                 && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var width)
                 && double.TryParse(Height.AsSpan(0, Height.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
             {
                 _boundWidth = width;
                 _boundHeight = height;
+            }
+            else if (isWidthFixed
+                && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var fixedWidth))
+            {
+                _boundWidth = fixedWidth;
             }
         }
     }

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Numerics;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
@@ -250,18 +251,33 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
 
         if (MatchBoundsToSize)
         {
+            var isWidthFixed = Width.EndsWith("px");
+            var isHeightFixed = Height.EndsWith("px");
+
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                var minDimension = isHeightFixed
+                    ? Math.Min(_elementSize.Width, _elementSize.Height)
+                    : Math.Min(_elementSize.Width, BoundHeightDefault);
+
+                _boundWidth = minDimension;
+                _boundHeight = minDimension;
             }
-            else if (Width.EndsWith("px")
-                && Height.EndsWith("px")
-                && double.TryParse(Width.AsSpan(0, Width.Length - 2), out var width)
-                && double.TryParse(Height.AsSpan(0, Height.Length - 2), out var height))
+            else if (isWidthFixed
+                && isHeightFixed
+                && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var width)
+                && double.TryParse(Height.AsSpan(0, Height.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
             {
-                _boundWidth = width;
-                _boundHeight = height;
+                var minDimension = Math.Min(width, height);
+                _boundWidth = minDimension;
+                _boundHeight = minDimension;
+            }
+            else if (isWidthFixed
+                && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var fixedWidth))
+            {
+                var minDimension = Math.Min(fixedWidth, BoundHeightDefault);
+                _boundWidth = minDimension;
+                _boundHeight = minDimension;
             }
         }
     }
@@ -371,7 +387,11 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
             return;
         }
 
-        var minDimension = Math.Min(_elementSize.Width, _elementSize.Height);
+        var isHeightFixed = Height.EndsWith("px");
+        var minDimension = isHeightFixed
+            ? Math.Min(_elementSize.Width, _elementSize.Height)
+            : Math.Min(_elementSize.Width, BoundHeightDefault);
+
         _boundWidth = minDimension;
         _boundHeight = minDimension;
 


### PR DESCRIPTION
Prevent infinite expansion loop in MudChart when MatchBoundsToSize is true and Height is relative (percentage/auto). Axis and Radial charts now fallback to a default height for their internal coordinate system (viewBox) in these cases, while remaining responsive to width changes.

---
*PR created automatically by Jules for task [15894466197699087464](https://jules.google.com/task/15894466197699087464) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for chart size matching behavior with percentage and pixel dimensions.

* **Bug Fixes**
  * Improved chart bounds calculation to prevent layout expansion loops when using percentage-based height dimensions.
  * Enhanced handling and parsing of fixed pixel dimensions in charts for more accurate and consistent sizing across all chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->