### PR TITLE
Allow MudSelect to use ToStringFunc for selection display when items have custom RenderFragments

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectToStringPrecedenceExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/Examples/SelectToStringPrecedenceExample.razor
@@ -1,0 +1,25 @@
+﻿@namespace MudBlazor.Docs.Examples
+
+<MudSelect @bind-Value="country" Label="ToStringFunc Precedence" Variant="Variant.Outlined" ToStringFunc="@GetCountryCode">
+    <MudSelectItem Value="@("Austria")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/41/Flag_of_Austria.svg" height="14" class="mr-1" /> Austria
+    </MudSelectItem>
+    <MudSelectItem Value="@("Hungary")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/0/00/Flag_of_Hungary.png" height="14" class="mr-1" /> Hungary
+    </MudSelectItem>
+    <MudSelectItem Value="@("Sweden")">
+        <img src="https://upload.wikimedia.org/wikipedia/commons/4/4b/Flag_of_Sweden_fixed.svg" height="14" class="mr-1" /> Sweden
+    </MudSelectItem>
+</MudSelect>
+
+@code {
+    string country = "Austria";
+
+    private string GetCountryCode(string name) => name switch
+    {
+        "Austria" => "🇦🇹 AUT",
+        "Hungary" => "🇭🇺 HUN",
+        "Sweden" => "🇸🇪 SWE",
+        _ => name
+    };
+}

--- a/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Select/SelectPage.razor
@@ -106,11 +106,25 @@
                 <Description>
                     Select uses the render fragments you specify for the items to display the selected value (if any). If you don't specify render fragments, the value will be displayed as text. Also, if you have render fragments
                     but the value that has been set is not in the list, it will also be displayed as text.
+                    <br /><br />
+                    If you provide a <CodeInline>ToStringFunc</CodeInline>, it takes precedence over the item's render fragment for the selection display, provided it returns a non-empty string.
                 </Description>
             </SectionHeader>
             <SectionContent ShowCode="false" Code="@nameof(SelectPresentationExample)">
                 <SelectPresentationExample />
             </SectionContent>
+            <SectionSubGroups>
+                <DocsPageSection>
+                    <SectionHeader Title="ToStringFunc Precedence">
+                        <Description>
+                            In this example, the dropdown items show the flag and full country name using render fragments. However, the selected value display uses the <CodeInline>ToStringFunc</CodeInline> to show an emoji flag and a 3-character country code.
+                        </Description>
+                    </SectionHeader>
+                    <SectionContent ShowCode="false" Code="@nameof(SelectToStringPrecedenceExample)">
+                        <SelectToStringPrecedenceExample />
+                    </SectionContent>
+                </DocsPageSection>
+            </SectionSubGroups>
         </DocsPageSection>
 
         <DocsPageSection>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
@@ -1,6 +1,6 @@
 @namespace MudBlazor.UnitTests.TestComponents.Select
 
-<MudSelect @ref="Select" T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpper())" Value="@("item1")">
+<MudSelect @ref="Select" T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpperInvariant())" Value="@("item1")">
     <MudSelectItem Value="@("item1")">
         <span class="custom-render">Item 1 Rendered</span>
     </MudSelectItem>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectPrecedenceTest.razor
@@ -1,0 +1,14 @@
+@namespace MudBlazor.UnitTests.TestComponents.Select
+
+<MudSelect @ref="Select" T="string" Label="Select" ToStringFunc="@(x => x == "item1" ? null : x?.ToUpper())" Value="@("item1")">
+    <MudSelectItem Value="@("item1")">
+        <span class="custom-render">Item 1 Rendered</span>
+    </MudSelectItem>
+    <MudSelectItem Value="@("item2")">
+        <span class="custom-render">Item 2 Rendered</span>
+    </MudSelectItem>
+</MudSelect>
+
+@code {
+    public MudSelect<string>? Select { get; set; }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
@@ -1,0 +1,77 @@
+using AwesomeAssertions;
+using Bunit;
+using MudBlazor.UnitTests.TestComponents.Select;
+using NUnit.Framework;
+using System.Linq;
+using System.Threading.Tasks;
+using System;
+
+#nullable enable
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class SelectPrecedenceTests : BunitTest
+    {
+        [Test]
+        public async Task Select_ToStringFunc_ShouldTakePrecedenceOverChildContent()
+        {
+            var comp = Context.Render<SelectPrecedenceTest>();
+            var select = comp.Instance.Select;
+
+            // 1. Initially item1 is selected. ToStringFunc returns null for item1.
+            // Should fall back to RenderFragment.
+            var displaySlots = comp.FindAll("div.mud-input-slot");
+            var displaySlot = displaySlots.FirstOrDefault(x => x.GetAttribute("style")?.Contains("display:inline") == true || x.GetAttribute("style")?.Contains("display: inline") == true);
+            displaySlot.Should().NotBeNull("initially it should fall back to RenderFragment");
+            displaySlot.InnerHtml.Should().Contain("custom-render");
+            displaySlot.TextContent.Trim().Should().Be("Item 1 Rendered");
+
+            // 2. Select item2. ToStringFunc returns "ITEM2" (not null).
+            // Should use ToStringFunc and NOT RenderFragment.
+            await comp.InvokeAsync(() => select!.SelectOption("item2"));
+            comp.Render();
+
+            displaySlots = comp.FindAll("div.mud-input-slot");
+            displaySlot = displaySlots.FirstOrDefault(x => x.GetAttribute("style")?.Contains("display:inline") == true || x.GetAttribute("style")?.Contains("display: inline") == true);
+            displaySlot.Should().BeNull("because ToStringFunc should take precedence over RenderFragment when it returns a non-null value");
+
+            var input = comp.Find("input");
+            input.GetAttribute("value").Should().Be("ITEM2");
+        }
+
+        [Test]
+        public async Task Select_FitContent_ShouldPrioritizeToStringFunc()
+        {
+            var comp = Context.Render<SelectPrecedenceTest>();
+            var selectComponent = comp.FindComponent<MudSelect<string>>();
+
+            // Remove label to avoid it being the longest
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.FitContent, true)
+                .Add(x => x.Label, null)
+                .Add(x => x.ToStringFunc, new Func<string, string?>(x => x == "item2" ? "VERY LONG ITEM 2" : null)));
+
+            // item1 -> null -> "Item 1 Rendered" (15 chars)
+            // item2 -> "VERY LONG ITEM 2" (16 chars)
+
+            // item2 is longest. ToStringFunc is NOT null for item2.
+            // filler should use "VERY LONG ITEM 2" and NOT RenderFragment.
+
+            var filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Should().Contain("VERY LONG ITEM 2");
+            filler.InnerHtml.Should().NotContain("custom-render");
+
+            // Now make item1 longest via ToStringFunc
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ToStringFunc, new Func<string, string?>(x => x == "item1" ? "EXTREMELY LONG ITEM 1" : "ITEM 2")));
+
+            // Trigger recalculation of _longestItem by toggling FitContent
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.FitContent, false));
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.FitContent, true));
+
+            filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Should().Contain("EXTREMELY LONG ITEM 1");
+            filler.InnerHtml.Should().NotContain("custom-render");
+        }
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
@@ -50,7 +50,7 @@ namespace MudBlazor.UnitTests.Components
             await selectComponent.SetParametersAndRenderAsync(parameters => parameters
                 .Add(x => x.FitContent, true)
                 .Add(x => x.Label, null)
-                .Add(x => x.ToStringFunc, new Func<string, string?>(x => x == "item2" ? "VERY LONG ITEM 2" : null)));
+                .Add(x => x.ToStringFunc, new Func<string?, string?>(x => x == "item2" ? "VERY LONG ITEM 2" : null)));
 
             // item1 -> null -> "Item 1 Rendered" (15 chars)
             // item2 -> "VERY LONG ITEM 2" (16 chars)
@@ -63,7 +63,7 @@ namespace MudBlazor.UnitTests.Components
             filler.InnerHtml.Should().NotContain("custom-render");
 
             // Now make item1 longest via ToStringFunc
-            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ToStringFunc, new Func<string, string?>(x => x == "item1" ? "EXTREMELY LONG ITEM 1" : "ITEM 2")));
+            await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.ToStringFunc, new Func<string?, string?>(x => x == "item1" ? "EXTREMELY LONG ITEM 1" : "ITEM 2")));
 
             // Trigger recalculation of _longestItem by toggling FitContent
             await selectComponent.SetParametersAndRenderAsync(parameters => parameters.Add(x => x.FitContent, false));

--- a/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectPrecedenceTests.cs
@@ -1,10 +1,10 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
 using AwesomeAssertions;
 using Bunit;
 using MudBlazor.UnitTests.TestComponents.Select;
 using NUnit.Framework;
-using System.Linq;
-using System.Threading.Tasks;
-using System;
 
 #nullable enable
 

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -71,7 +71,7 @@
                         {
                             <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([defaultValue]) ?? defaultValue)</MudText>
                         }
-                        else if (_longestItem?.ChildContent is null || MultiSelectionTextFunc is not null)
+                        else if (_longestItem?.ChildContent is null || MultiSelectionTextFunc is not null || !string.IsNullOrEmpty(ToStringFunc?.Invoke(_longestItem.Value)))
                         {
                             <MudText Typo="@Typo">@(MultiSelectionTextFunc?.Invoke([value!]) ?? value!)</MudText>
                         }

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -477,8 +477,13 @@ namespace MudBlazor
             {
                 if (MultiSelection)
                     return false;
+
+                if (ToStringFunc is not null && !string.IsNullOrEmpty(ToStringFunc(ReadValue)))
+                    return false;
+
                 if (!_context.TryGetShadowItemByValue(ReadValue, out var item))
                     return false;
+
                 return item.ChildContent != null;
             }
         }


### PR DESCRIPTION
This PR implements the request in issue 12729 by changing the precedence of how the selected value is displayed in `MudSelect`.

Previously, if a `MudSelectItem` had `ChildContent` (a `RenderFragment`), it would always be used for the selection display in the select box, even if the parent `MudSelect` had a `ToStringFunc` defined.

With this change:
1. If `ToStringFunc` is provided and returns a non-null, non-empty string for the selected value, that string will be displayed in the select box (as text).
2. If `ToStringFunc` is not provided, or returns a null/empty string, the component falls back to displaying the `ChildContent` of the selected item (if any).
3. The items inside the popover (dropdown list) continue to use their `ChildContent` as before.
4. The `FitContent` property correctly accounts for this precedence when calculating the required width of the component.

Verified with new unit tests and existing test suite.

---
*PR created automatically by Jules for task [8657896899349017070](https://jules.google.com/task/8657896899349017070) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selected-value rendering now consistently prioritizes custom string conversion over item render fragments, including when FitContent is enabled.
* **Documentation**
  * Added example and a new documentation subsection demonstrating ToStringFunc precedence for selected-value presentation.
* **Tests**
  * Added unit tests and a test component validating display precedence and FitContent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->