### PR TITLE
Fix MudDatePicker mask text not clearing

### DIFF
--- a/src/MudBlazor.UnitTests/Components/DatePickerMaskTests.cs
+++ b/src/MudBlazor.UnitTests/Components/DatePickerMaskTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Bunit;
+using MudBlazor.UnitTests.TestComponents;
+using NUnit.Framework;
+using AwesomeAssertions;
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class DatePickerMaskTests : BunitTest
+    {
+        [Test]
+        public async Task DatePicker_WithMask_ShouldClearText_WhenDateSetToNull()
+        {
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(p => p.Mask, new DateMask("dd/MM/yyyy"))
+                .Add(p => p.Date, new DateTime(2021, 1, 1))
+            );
+            var picker = comp.Instance;
+
+            picker.Text.Should().Be("01/01/2021");
+
+            await comp.SetParametersAndRenderAsync(parameters => parameters.Add(p => p.Date, null));
+
+            picker.Date.Should().BeNull();
+            picker.Text.Should().BeNullOrEmpty();
+
+            var input = comp.Find("input");
+            input.GetAttribute("value").Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task DatePicker_WithMask_ShouldClearText_WhenClearAsyncCalled()
+        {
+            var comp = Context.Render<MudDatePicker>(parameters => parameters
+                .Add(p => p.Mask, new DateMask("dd/MM/yyyy"))
+                .Add(p => p.Date, new DateTime(2021, 1, 1))
+            );
+            var picker = comp.Instance;
+
+            picker.Text.Should().Be("01/01/2021");
+
+            await comp.InvokeAsync(() => picker.ClearAsync());
+
+            picker.Date.Should().BeNull();
+            picker.Text.Should().BeNullOrEmpty();
+
+            var input = comp.Find("input");
+            input.GetAttribute("value").Should().BeNullOrEmpty();
+        }
+    }
+}

--- a/src/MudBlazor/Components/Mask/MudMask.razor.cs
+++ b/src/MudBlazor/Components/Mask/MudMask.razor.cs
@@ -291,14 +291,12 @@ namespace MudBlazor
                 return;
             var text = ConvertSet(ReadValue);
             var cleanText = Mask.GetCleanText();
-            if (string.IsNullOrEmpty(cleanText) && string.IsNullOrEmpty(text))
-                return;
 
             if (cleanText != text)
             {
                 var maskText = Mask.Text;
                 Mask.SetText(text);
-                if (maskText == Mask.Text)
+                if (maskText == Mask.Text && ReadText == Mask.Text)
                     return;
             }
 


### PR DESCRIPTION
Fixed an issue where `MudDatePicker` with a mask would continue to display the previously selected date even after the `Date` property was set to `null` or `ClearAsync()` was called.

The root cause was in the `MudMask` component, which `MudDatePicker` uses for masked input. `MudMask` had a guard in its `UpdateTextPropertyAsync` method that would return early if both the current "clean" text and the new text were empty, which prevented it from clearing its internal `Text` property if it was currently displaying a formatted date string.

Changes:
- Modified `src/MudBlazor/Components/Mask/MudMask.razor.cs` to ensure that the displayed text is updated if it differs from the mask's internal state, even when the values are empty.
- Added a new test file `src/MudBlazor.UnitTests/Components/DatePickerMaskTests.cs` to verify the fix and prevent regressions.

Verified the fix with new and existing tests.

---
*PR created automatically by Jules for task [9956052474653709350](https://jules.google.com/task/9956052474653709350) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text clearing behavior in masked date picker components when the date is set to null or when the clear operation is invoked.

* **Tests**
  * Added unit tests validating that masked date picker properly clears formatted text and input values when clearing the date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->