### PR TITLE
Fix Appbar active state on navigation

### DIFF
--- a/src/MudBlazor.Docs/Shared/Appbar.razor.cs
+++ b/src/MudBlazor.Docs/Shared/Appbar.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
 using MudBlazor.Docs.Models;
 using MudBlazor.Docs.Services;
@@ -11,7 +12,7 @@ using MudBlazor.Utilities;
 namespace MudBlazor.Docs.Shared;
 
 #nullable enable
-public partial class Appbar
+public partial class Appbar : IDisposable
 {
     private bool _searchDialogOpen;
     private bool _searchDialogAutocompleteOpen;
@@ -47,6 +48,22 @@ public partial class Appbar
 
     [Parameter]
     public bool DisplaySearchBar { get; set; } = true;
+
+    protected override void OnInitialized()
+    {
+        NavigationManager.LocationChanged += OnLocationChanged;
+        base.OnInitialized();
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        NavigationManager.LocationChanged -= OnLocationChanged;
+    }
 
     private async Task OnSearchResult(ApiLinkServiceEntry? entry)
     {


### PR DESCRIPTION
The Appbar header items (Get Started, Docs, Learn More) were not updating their active state when navigating via the sidebar or other internal links. This was because the Appbar component was not re-rendering on location changes.

This change:
- Implements IDisposable in Appbar.razor.cs.
- Subscribes to NavigationManager.LocationChanged in OnInitialized.
- Triggers StateHasChanged in the LocationChanged event handler to refresh the active state of header buttons.
- Unsubscribes from the event in Dispose to prevent memory leaks.

---
*PR created automatically by Jules for task [8857720347273424574](https://jules.google.com/task/8857720347273424574) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Appbar component to properly update when navigating between pages. The component now correctly refreshes its state on location changes and properly cleans up resources when disposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->