### PR TITLE
MudFabMenu: add Direction and Anchor support, fix AppBar occlusion

### DIFF
--- a/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
+++ b/src/MudBlazor.UnitTests/Components/FabMenuTests.cs
@@ -71,4 +71,37 @@ public class FabMenuTests : BunitTest
         await comp.FindAll(".mud-fab-menu-container")[0].MouseLeaveAsync(new MouseEventArgs());
         await comp.WaitForAssertionAsync(() => { comp.FindAll(".mud-fab-menu.mud-fab-menu-open").Count.Should().Be(0); });
     }
+
+    [Test]
+    public void DirectionClasses_ShouldBeApplied()
+    {
+        foreach (Direction direction in Enum.GetValues(typeof(Direction)))
+        {
+            var comp = Context.Render<MudFabMenu>(parameters => parameters.Add(p => p.Direction, direction));
+            comp.Find(".mud-fab-menu").ClassList.Should().Contain($"mud-fab-menu-direction-{direction.ToStringFast(true)}");
+        }
+    }
+
+    [Test]
+    public void AnchorClasses_ShouldBeApplied_WhenFixed()
+    {
+        foreach (Origin anchor in Enum.GetValues(typeof(Origin)))
+        {
+            var comp = Context.Render<MudFabMenu>(parameters => parameters
+                .Add(p => p.Fixed, true)
+                .Add(p => p.Anchor, anchor));
+            comp.Find(".mud-fab-menu-container").ClassList.Should().Contain("fixed");
+            comp.Find(".mud-fab-menu-container").ClassList.Should().Contain($"mud-fab-anchor-{anchor.ToStringFast(true)}");
+        }
+    }
+
+    [Test]
+    public void AnchorClasses_ShouldNotBeApplied_WhenNotFixed()
+    {
+        var comp = Context.Render<MudFabMenu>(parameters => parameters
+            .Add(p => p.Fixed, false)
+            .Add(p => p.Anchor, Origin.TopLeft));
+        comp.Find(".mud-fab-menu-container").ClassList.Should().NotContain("fixed");
+        comp.Find(".mud-fab-menu-container").ClassList.Should().NotContain("mud-fab-anchor-top-left");
+    }
 }

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -13,6 +13,7 @@ public partial class MudFabMenu : MudFab
 {
     private new string Classname => new CssBuilder("mud-fab-menu-container")
         .AddClass("fixed", Fixed)
+        .AddClass($"mud-fab-anchor-{Anchor.ToStringFast(true)}", Fixed)
         .AddClass($"align-{AlignItems.ToStringFast(true)}")
         .AddClass(Class)
         .Build();
@@ -20,6 +21,7 @@ public partial class MudFabMenu : MudFab
     private string ClassnameMenu => new CssBuilder("mud-fab-menu")
         .AddClass("mud-fab-menu-open", _openState.Value)
         .AddClass("mud-fab-menu-dampen", DampenItemsBackgroundColor)
+        .AddClass($"mud-fab-menu-direction-{Direction.ToStringFast(true)}")
         .AddClass($"align-{AlignItems.ToStringFast(true)}")
         .AddClass($"mud-fab-menu-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
         .AddClass(MenuClass)
@@ -90,13 +92,31 @@ public partial class MudFabMenu : MudFab
     public EventCallback<bool> OpenChanged { get; set; }
 
     /// <summary>
-    /// Sets the menu to a fixed position in the bottom right corner of the screen with padding of 16 px towards each screen edge.
+    /// Sets the menu to a fixed position. Use <see cref="Anchor"/> to specify the position.
     /// </summary>
     /// <remarks>
     /// Defaults to <c>false</c>.
     /// </remarks>
     [Parameter, Category(CategoryTypes.Button.Behavior)]
     public bool Fixed { get; set; }
+
+    /// <summary>
+    /// The direction in which the menu should open.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Direction.Top"/>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
+    public Direction Direction { get; set; } = Direction.Top;
+
+    /// <summary>
+    /// The anchor position of the menu when <see cref="Fixed"/> is <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="Origin.BottomRight"/>.
+    /// </remarks>
+    [Parameter, Category(CategoryTypes.Button.Behavior)]
+    public Origin Anchor { get; set; } = Origin.BottomRight;
 
     /// <summary>
     /// Replaces the set icon with a close icon when the menu is open.

--- a/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
+++ b/src/MudBlazor/Components/Button/MudFabMenu.razor.cs
@@ -23,7 +23,6 @@ public partial class MudFabMenu : MudFab
         .AddClass("mud-fab-menu-dampen", DampenItemsBackgroundColor)
         .AddClass($"mud-fab-menu-direction-{Direction.ToStringFast(true)}")
         .AddClass($"align-{AlignItems.ToStringFast(true)}")
-        .AddClass($"mud-fab-menu-{Size.ToString().ToLower()}", !string.IsNullOrEmpty(Label))
         .AddClass(MenuClass)
         .Build();
 

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -66,8 +66,7 @@
 
     // Default direction: Top
     &.mud-fab-menu-direction-top {
-      bottom: 0;
-      padding-bottom: calc(100% + 12px);
+      bottom: calc(100% + 12px);
       flex-direction: column-reverse;
       align-items: center;
       width: 100%;
@@ -78,8 +77,7 @@
     }
 
     &.mud-fab-menu-direction-bottom {
-      top: 0;
-      padding-top: calc(100% + 12px);
+      top: calc(100% + 12px);
       flex-direction: column;
       align-items: center;
       width: 100%;
@@ -90,8 +88,7 @@
     }
 
     &.mud-fab-menu-direction-left {
-      right: 0;
-      padding-right: calc(100% + 12px);
+      right: calc(100% + 12px);
       flex-direction: row-reverse;
       align-items: center;
       height: 100%;
@@ -102,8 +99,7 @@
     }
 
     &.mud-fab-menu-direction-right {
-      left: 0;
-      padding-left: calc(100% + 12px);
+      left: calc(100% + 12px);
       flex-direction: row;
       align-items: center;
       height: 100%;
@@ -114,8 +110,7 @@
     }
 
     &.mud-fab-menu-direction-start {
-      inset-inline-end: 0;
-      padding-inline-end: calc(100% + 12px);
+      inset-inline-end: calc(100% + 12px);
       flex-direction: row-reverse;
       align-items: center;
       height: 100%;
@@ -130,8 +125,7 @@
     }
 
     &.mud-fab-menu-direction-end {
-      inset-inline-start: 0;
-      padding-inline-start: calc(100% + 12px);
+      inset-inline-start: calc(100% + 12px);
       flex-direction: row;
       align-items: center;
       height: 100%;

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -165,7 +165,11 @@
 
       .mud-fab-menu-item {
         opacity: 1;
-        transform: translate(0) !important;
+        transform: translate(0);
+
+        [dir='rtl'] & {
+          transform: translate(0);
+        }
       }
     }
 

--- a/src/MudBlazor/Styles/components/_fabmenu.scss
+++ b/src/MudBlazor/Styles/components/_fabmenu.scss
@@ -4,34 +4,145 @@
 
   &.fixed {
     position: fixed;
-    right: 16px;
-    bottom: 16px;
     z-index: calc(var(--mud-zindex-appbar) + 1);
+  }
+
+  &.mud-fab-anchor-top-left {
+    top: 16px;
+    left: 16px;
+  }
+
+  &.mud-fab-anchor-top-center {
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &.mud-fab-anchor-top-right {
+    top: 16px;
+    right: 16px;
+  }
+
+  &.mud-fab-anchor-center-left {
+    top: 50%;
+    left: 16px;
+    transform: translateY(-50%);
+  }
+
+  &.mud-fab-anchor-center-center {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &.mud-fab-anchor-center-right {
+    top: 50%;
+    right: 16px;
+    transform: translateY(-50%);
+  }
+
+  &.mud-fab-anchor-bottom-left {
+    bottom: 16px;
+    left: 16px;
+  }
+
+  &.mud-fab-anchor-bottom-center {
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &.mud-fab-anchor-bottom-right {
+    bottom: 16px;
+    right: 16px;
   }
 
   .mud-fab-menu {
     position: absolute;
-    bottom: 0;
-    right: 0;
-    padding-bottom: calc(100% + 12px);
     display: flex;
-    flex-direction: column-reverse;
-    align-items: center;
     gap: 12px;
-    z-index: calc(var(--mud-zindex-popover) - 2);
-    width: 100%;
+    z-index: calc(var(--mud-zindex-appbar) + 2);
     pointer-events: none;
 
-    &.mud-fab-menu-small {
-      padding-bottom: 48px;
+    // Default direction: Top
+    &.mud-fab-menu-direction-top {
+      bottom: 0;
+      padding-bottom: calc(100% + 12px);
+      flex-direction: column-reverse;
+      align-items: center;
+      width: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateY(20px);
+      }
     }
 
-    &.mud-fab-menu-medium {
-      padding-bottom: 52px;
+    &.mud-fab-menu-direction-bottom {
+      top: 0;
+      padding-top: calc(100% + 12px);
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateY(-20px);
+      }
     }
 
-    &.mud-fab-menu-large {
-      padding-bottom: 60px;
+    &.mud-fab-menu-direction-left {
+      right: 0;
+      padding-right: calc(100% + 12px);
+      flex-direction: row-reverse;
+      align-items: center;
+      height: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateX(20px);
+      }
+    }
+
+    &.mud-fab-menu-direction-right {
+      left: 0;
+      padding-left: calc(100% + 12px);
+      flex-direction: row;
+      align-items: center;
+      height: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateX(-20px);
+      }
+    }
+
+    &.mud-fab-menu-direction-start {
+      inset-inline-end: 0;
+      padding-inline-end: calc(100% + 12px);
+      flex-direction: row-reverse;
+      align-items: center;
+      height: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateX(20px);
+
+        [dir='rtl'] & {
+          transform: translateX(-20px);
+        }
+      }
+    }
+
+    &.mud-fab-menu-direction-end {
+      inset-inline-start: 0;
+      padding-inline-start: calc(100% + 12px);
+      flex-direction: row;
+      align-items: center;
+      height: 100%;
+
+      .mud-fab-menu-item {
+        transform: translateX(-20px);
+
+        [dir='rtl'] & {
+          transform: translateX(20px);
+        }
+      }
     }
 
     &.mud-fab-menu-dampen {
@@ -52,7 +163,6 @@
 
     .mud-fab-menu-item {
       opacity: 0;
-      transform: translateY(20px);
       transition: transform 0.3s ease, opacity 0.3s ease;
     }
 
@@ -61,7 +171,7 @@
 
       .mud-fab-menu-item {
         opacity: 1;
-        transform: translateY(0);
+        transform: translate(0) !important;
       }
     }
 
@@ -82,7 +192,7 @@
 
   .mud-fab-menu-button {
     transition: transform 0.3s ease, opacity 0.3s ease;
-    z-index: calc(var(--mud-zindex-popover) - 1);
+    z-index: calc(var(--mud-zindex-appbar) + 3);
 
     &.open {
       transform: rotate(45deg);


### PR DESCRIPTION
This change adds Direction and Anchor parameters to MudFabMenu, allowing it to open in any direction and be fixed to specific screen positions. It also fixes an issue where the menu was occluded by the AppBar and improves spacing for Extended FABs.

---
*PR created automatically by Jules for task [9245801060931112302](https://jules.google.com/task/9245801060931112302) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MudFabMenu adds Direction (controls open direction) and Anchor (controls fixed placement) options.
  * New anchor positions (top/center/bottom × left/center/right) and direction variants, including RTL-aware behavior.

* **Style**
  * Updated positioning, per-direction animations/transforms, and increased z-index to ensure proper stacking.

* **Tests**
  * Added unit tests verifying directional and anchor CSS class application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->