### PR TITLE
Fix MudSelect FitContent initial render and dynamic updates

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectFitContentTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Select/SelectFitContentTest.razor
@@ -24,7 +24,7 @@
     public bool FullWidth { get; set; }
 
     [Parameter]
-    public bool FitContent { get; set; }
+    public bool FitContent { get; set; } = true;
     
     private string? _selectedState;
     private readonly string[] _states =

--- a/src/MudBlazor.UnitTests/Components/SelectFitContentTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectFitContentTests.cs
@@ -1,0 +1,55 @@
+﻿using AwesomeAssertions;
+using Bunit;
+using MudBlazor.UnitTests.TestComponents.Select;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Components
+{
+    [TestFixture]
+    public class SelectFitContentTests : BunitTest
+    {
+        [Test]
+        public void SelectFitContent_Should_CalculateLongestItemOnInit()
+        {
+            // Initial render with FitContent=true
+            var comp = Context.Render<SelectFitContentTest>(parameters => parameters.Add(x => x.FitContent, true));
+
+            var filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Trim().Should().Be("Federated States of Micronesia");
+        }
+
+        [Test]
+        public async Task SelectFitContent_Should_UpdateLongestItemWhenItemsChange()
+        {
+            var comp = Context.Render<MudSelect<string>>(parameters => parameters
+                .Add(x => x.FitContent, true)
+                .Add(x => x.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudSelectItem<string>>(0);
+                    builder.AddAttribute(1, "Value", "Short");
+                    builder.CloseComponent();
+                }));
+
+            var filler = comp.Find(".mud-select-filler");
+            filler.TextContent.Trim().Should().Be("Short");
+
+            // Add a longer item
+            await comp.SetParametersAndRenderAsync(parameters => parameters
+                .Add(x => x.ChildContent, builder =>
+                {
+                    builder.OpenComponent<MudSelectItem<string>>(0);
+                    builder.AddAttribute(1, "Value", "Short");
+                    builder.CloseComponent();
+                    builder.OpenComponent<MudSelectItem<string>>(2);
+                    builder.AddAttribute(3, "Value", "This is a much longer item");
+                    builder.CloseComponent();
+                }));
+
+            await comp.WaitForAssertionAsync(() =>
+            {
+                filler = comp.Find(".mud-select-filler");
+                filler.TextContent.Trim().Should().Be("This is a much longer item");
+            });
+        }
+    }
+}

--- a/src/MudBlazor/Components/Select/MudSelect.razor.cs
+++ b/src/MudBlazor/Components/Select/MudSelect.razor.cs
@@ -24,6 +24,7 @@ namespace MudBlazor
         private bool? _selectAllChecked;
         private string? _multiSelectionText;
         private MudSelectItem<T>? _longestItem;
+        private bool _longestItemUpdateNeeded;
         private bool _needsHighlightAfterRender;
         private MudInput<string> _elementReference = null!;
         private HashSet<T?> _selectedValues = [];
@@ -65,6 +66,9 @@ namespace MudBlazor
             registerScope.RegisterParameter<bool>(nameof(FitContent))
                 .WithParameter(() => FitContent)
                 .WithChangeHandler(OnFitContentChanged);
+            registerScope.RegisterParameter<Func<T?, string?>?>(nameof(ToStringFunc))
+                .WithParameter(() => ToStringFunc)
+                .WithChangeHandler(UpdateLongestItem);
         }
 
         protected string OuterClassname =>
@@ -765,24 +769,50 @@ namespace MudBlazor
         {
             if (args.Value)
             {
-                var longestItemLength = 0;
-                foreach (var item in _context.ShadowItems)
-                {
-                    var value = item.Value;
-                    var valueToString = ConvertSet(value);
-                    var length = valueToString?.Length ?? 0;
-
-                    if (length > longestItemLength)
-                    {
-                        _longestItem = item;
-                        longestItemLength = length;
-                    }
-                }
-                StateHasChanged();
+                UpdateLongestItem();
             }
             else
             {
                 _longestItem = null;
+            }
+        }
+
+        private void UpdateLongestItem()
+        {
+            _longestItemUpdateNeeded = false;
+            if (!FitContent)
+            {
+                _longestItem = null;
+                return;
+            }
+
+            MudSelectItem<T>? newLongestItem = null;
+            var longestItemLength = -1;
+            foreach (var item in _context.ShadowItems)
+            {
+                var value = item.Value;
+                var valueToString = ConvertSet(value);
+                var length = valueToString?.Length ?? 0;
+
+                if (length >= longestItemLength)
+                {
+                    newLongestItem = item;
+                    longestItemLength = length;
+                }
+            }
+
+            if (_longestItem != newLongestItem)
+            {
+                _longestItem = newLongestItem;
+                StateHasChanged();
+            }
+        }
+
+        internal void NotifyShadowItemsChanged()
+        {
+            if (FitContent)
+            {
+                _longestItemUpdateNeeded = true;
             }
         }
 
@@ -1224,6 +1254,11 @@ namespace MudBlazor
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
         {
+            if (_longestItemUpdateNeeded)
+            {
+                UpdateLongestItem();
+            }
+
             if (firstRender)
             {
                 var options = new KeyInterceptorOptions(
@@ -1407,6 +1442,16 @@ namespace MudBlazor
             }
 
             return base.HasValue(value);
+        }
+
+        protected override async Task OnConverterChangedAsync()
+        {
+            await base.OnConverterChangedAsync();
+            if (FitContent)
+            {
+                UpdateLongestItem();
+            }
+            await UpdateTextPropertyAsync(false);
         }
 
         /// <inheritdoc />

--- a/src/MudBlazor/Components/Select/MudSelectContext.cs
+++ b/src/MudBlazor/Components/Select/MudSelectContext.cs
@@ -106,6 +106,7 @@ internal sealed class MudSelectContext<T>
         }
 
         _shadowLookup[item.Value] = item;
+        _select.NotifyShadowItemsChanged();
     }
 
     /// <summary>
@@ -120,6 +121,7 @@ internal sealed class MudSelectContext<T>
         }
 
         _shadowLookup.Remove(item.Value);
+        _select.NotifyShadowItemsChanged();
     }
 
     /// <summary>


### PR DESCRIPTION
Currently, the `MudSelect` `_longestItem` (used for `FitContent` sizing) is only calculated during `OnParametersSet`. However, shadow items are often not yet registered during the first execution of `OnParametersSet`, leading to `_longestItem` remaining null. This makes it appear as though `FitContent` does not work until it's toggled manually.

This PR fixes this by:
1.  Introducing a `_longestItemUpdateNeeded` flag that is set whenever shadow items register or unregister with the `MudSelectContext`.
2.  Processing this flag in `OnAfterRenderAsync`, ensuring that the calculation occurs after the items have had a chance to register themselves during the render cycle.
3.  Ensuring that changes to `ToStringFunc` or the `Converter` also trigger a recalculation, as they affect the string length of the items.
4.  Adding unit tests to verify that `FitContent` works on initial render and correctly updates when the item collection changes.

---
*PR created automatically by Jules for task [6807053762479331502](https://jules.google.com/task/6807053762479331502) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Select component FitContent feature now correctly identifies and tracks the longest item on initialization, and dynamically updates when items are modified or string converters change, ensuring proper content fitting.

* **Tests**
  * Added comprehensive unit tests to validate Select FitContent behavior, including initial calculation and response to item changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->