### PR TITLE
Fix infinite height growth in MudChart when MatchBoundsToSize is enabled

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -19,6 +19,7 @@ public class ChartSizingTests : BunitTest
         var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Bar)
             .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Height, "400px")
             .Add(p => p.ChartSeries, chartSeries));
 
         // Find the internal Bar component
@@ -46,6 +47,7 @@ public class ChartSizingTests : BunitTest
         var comp = Context.Render<MudChart<double>>(parameters => parameters
             .Add(p => p.ChartType, ChartType.Line)
             .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Height, "500px")
             .Add(p => p.ChartSeries, chartSeries));
 
         // Find the internal Line component
@@ -140,7 +142,8 @@ public class ChartSizingTests : BunitTest
         await Task.Delay(300);
 
         svg = comp.Find("svg");
-        svg.GetAttribute("viewBox").Should().Be("0 0 700 400");
+        // Should still be 350 because height is 80% (not px)
+        svg.GetAttribute("viewBox").Should().Be("0 0 700 350");
     }
 
     [Test]

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -233,17 +233,30 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
                     ? _elementSize.Width
                     : BoundWidthDefault;
 
-                _boundHeight = _elementSize.Height > 0
-                    ? _elementSize.Height
-                    : BoundHeightDefault;
+                if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase))
+                {
+                    _boundHeight = _elementSize.Height > 0
+                        ? _elementSize.Height
+                        : BoundHeightDefault;
+                }
+                else
+                {
+                    _boundHeight = BoundHeightDefault;
+                }
             }
-            else if (Width.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
-                && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
-                && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var width)
-                && double.TryParse(Height.AsSpan(0, Height.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
+            else
             {
-                _boundWidth = width;
-                _boundHeight = height;
+                if (Width is not null && Width.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
+                    && double.TryParse(Width.AsSpan(0, Width.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var width))
+                {
+                    _boundWidth = width;
+                }
+
+                if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
+                    && double.TryParse(Height.AsSpan(0, Height.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var height))
+                {
+                    _boundHeight = height;
+                }
             }
         }
     }
@@ -369,6 +382,21 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
         _elementSize = elementSize;
 
         if (!MatchBoundsToSize)
+        {
+            return;
+        }
+
+        var oldBoundWidth = _boundWidth;
+        var oldBoundHeight = _boundHeight;
+
+        _boundWidth = _elementSize.Width;
+
+        if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase))
+        {
+            _boundHeight = _elementSize.Height;
+        }
+
+        if (oldBoundWidth == _boundWidth && oldBoundHeight == _boundHeight)
         {
             return;
         }

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -252,16 +252,31 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
         {
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase))
+                {
+                    var minDimension = Math.Min(_elementSize.Width, _elementSize.Height);
+                    _boundWidth = minDimension;
+                    _boundHeight = minDimension;
+                }
+                else
+                {
+                    _boundWidth = _elementSize.Width;
+                    _boundHeight = BoundHeightDefault;
+                }
             }
-            else if (Width.EndsWith("px")
-                && Height.EndsWith("px")
-                && double.TryParse(Width.AsSpan(0, Width.Length - 2), out var width)
-                && double.TryParse(Height.AsSpan(0, Height.Length - 2), out var height))
+            else
             {
-                _boundWidth = width;
-                _boundHeight = height;
+                if (Width is not null && Width.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
+                    && double.TryParse(Width.AsSpan(0, Width.Length - 2), out var width))
+                {
+                    _boundWidth = width;
+                }
+
+                if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
+                    && double.TryParse(Height.AsSpan(0, Height.Length - 2), out var height))
+                {
+                    _boundHeight = height;
+                }
             }
         }
     }
@@ -371,9 +386,25 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
             return;
         }
 
-        var minDimension = Math.Min(_elementSize.Width, _elementSize.Height);
-        _boundWidth = minDimension;
-        _boundHeight = minDimension;
+        var oldBoundWidth = _boundWidth;
+        var oldBoundHeight = _boundHeight;
+
+        if (Height is not null && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase))
+        {
+            var minDimension = Math.Min(_elementSize.Width, _elementSize.Height);
+            _boundWidth = minDimension;
+            _boundHeight = minDimension;
+        }
+        else
+        {
+            _boundWidth = _elementSize.Width;
+            _boundHeight = BoundHeightDefault;
+        }
+
+        if (oldBoundWidth == _boundWidth && oldBoundHeight == _boundHeight)
+        {
+            return;
+        }
 
         _debouncer.DebounceAsync(async () =>
         {


### PR DESCRIPTION
Prevent MudChart from increasing its height indefinitely when MatchBoundsToSize is used with percentage-based heights (e.g., the default '80%'). This is achieved by only using the observed element height for the internal viewBox if the Height parameter is specified in pixels. Otherwise, it falls back to a stable default height (350 for axis charts, 280 for radial charts) to break the feedback loop where the SVG viewBox expansion causes the container to grow, triggering further resize events.

Also added null checks for Width and Height parameters before calling AsSpan() and ensured safe access to _elementSize.

---
*PR created automatically by Jules for task [16639600674589907994](https://jules.google.com/task/16639600674589907994) started by @Anu6is*