### PR TITLE
respect defined chart height when MatchBoundsToSize=true

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/TimeSeriesChartTests.cs
@@ -135,7 +135,7 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.MatchBoundsToSize, true));
 
             // check the size/bounds
-            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"100%\" height=\"100%\" viewBox=\"0 0 1000 400\"");
+            comp.Markup.Should().ContainEquivalentOf("<svg class=\"mud-chart-line mud-ltr\" width=\"1000px\" height=\"400px\" viewBox=\"0 0 1000 400\"");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -6,8 +6,7 @@
 @typeparam TChartOptions
 
 <svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" 
-     width="@(MatchBoundsToSize ? "100%" : Width)" height="@(MatchBoundsToSize ? "100%" : Height)" 
-     viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
+     width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
      style="@HoveredStylename">
     <Filters />
 

--- a/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisChartBase.cs
@@ -172,7 +172,10 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     {
         base.OnParametersSet();
 
-        if (MatchBoundsToSize && _elementSize is null) return;
+        if (MatchBoundsToSize && _elementSize is null)
+        {
+            return;
+        }
 
         RebuildChart();
     }
@@ -229,8 +232,13 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
         {
             if (_elementSize is not null)
             {
-                _boundWidth = _elementSize.Width;
-                _boundHeight = _elementSize.Height;
+                _boundWidth = _elementSize.Width > 0
+                    ? _elementSize.Width
+                    : BoundWidthDefault;
+
+                _boundHeight = _elementSize.Height > 0
+                    ? _elementSize.Height
+                    : BoundHeightDefault;
             }
             else if (Width.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
                 && Height.AsSpan().Trim().EndsWith("px", StringComparison.OrdinalIgnoreCase)
@@ -336,7 +344,9 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     protected static string FormatTooltipText(string? format, ChartSeries<T> series, SvgPath path)
     {
         if (string.IsNullOrWhiteSpace(format))
+        {
             return string.Empty;
+        }
 
         return format
             .Replace("{{SERIES_NAME}}", series.Name)
@@ -352,12 +362,16 @@ public abstract class MudAxisChartBase<T, TOptions> : MudChartBase<T, TOptions>,
     public void OnElementSizeChanged(ElementSize elementSize)
     {
         if (elementSize is null || elementSize.Timestamp <= _elementSize?.Timestamp)
+        {
             return;
+        }
 
         _elementSize = elementSize;
 
         if (!MatchBoundsToSize)
+        {
             return;
+        }
 
         if (Math.Abs(_boundWidth - _elementSize.Width) < Epsilon &&
             Math.Abs(_boundHeight - _elementSize.Height) < Epsilon)

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -11,8 +11,7 @@
 }
 
 <svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" 
-     width="@(MatchBoundsToSize ? "100%" : Width)" height="@(MatchBoundsToSize ? "100%" : Height)"
-     viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
+     width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
      style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
     {

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -9,9 +9,17 @@
 @attribute [CascadingTypeParameter(nameof(T))]
 
 <CascadingValue Value="@this" IsFixed="true">
-    <div @attributes="UserAttributes" class="@Classname" style="@Style; width: @Width; height: @Height;" dir="ltr">
-        @ChartContent
-    </div>
+    @if (_hasFixedParent)
+    {
+        @ChartContainer
+    }
+    else
+    {
+        <div style="height:@(IsHeightPercentage() ? FallbackHeight : Height); width: @Width;">
+            @ChartContainer
+        </div>
+    }
+
     @if (ChartReference is not null)
     {
         <CascadingValue Value="@ChartReference" IsFixed="true">
@@ -21,6 +29,14 @@
 </CascadingValue>
 
 @code {
+    private RenderFragment ChartContainer => @<div @ref="_containerRef"
+                                                   @attributes="UserAttributes"
+                                                   class="@Classname"
+                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {@Height};")"
+                                                   dir="ltr">
+        @ChartContent
+    </div>;
+
     private RenderFragment ChartContent => (_chartType, _chartOptions) switch
     {
         (ChartType.Donut, DonutChartOptions donutOptions) => @<Donut ChartSeries="@ChartSeries"

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Numerics;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
 using MudBlazor.Charts;
 
 namespace MudBlazor;
@@ -12,8 +14,20 @@ namespace MudBlazor;
 /// </summary>
 public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, IFormattable
 {
+    [Inject]
+    private IJSRuntime JsRuntime { get; set; } = null!;
+
+    private bool _hasFixedParent = true;
+
     private ChartType? _chartType;
     private IChartOptions? _chartOptions;
+    private ElementReference? _containerRef;
+
+    /// <summary>
+    /// The pixel height used for the fallback wrapper div when <see cref="MudChartBase{T,TOptions}.Height"/>
+    /// is a percentage and no fixed-height ancestor is detected.
+    /// </summary>
+    private const string FallbackHeight = "400px";
 
     protected override void OnParametersSet()
     {
@@ -42,6 +56,28 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
 
         base.OnAfterRender(firstRender);
     }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!MatchBoundsToSize)
+        {
+            return;
+        }
+
+        if (firstRender && IsHeightPercentage())
+        {
+            _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
+
+            if (!_hasFixedParent)
+            {
+                StateHasChanged();
+            }
+        }
+    }
+
+    private bool IsHeightPercentage() => Height.AsSpan().Trim().EndsWith("%", StringComparison.Ordinal);
 
     private IChartOptions GetChartTypeOptions(ChartOptions options) => ChartType switch
     {

--- a/src/MudBlazor/TScripts/mudHelpers.js
+++ b/src/MudBlazor/TScripts/mudHelpers.js
@@ -112,6 +112,35 @@ window.mudGetSvgBBox = (svgElement) => {
 };
 
 /**
+ * Returns whether or not the element has a parent with a defined height,
+ * either via explicit height or constrained layout context.
+ */
+window.hasDefinedParentHeight = (element) => {
+    console.log('element:', element);
+    const parent = element?.parentElement;
+    console.log('parent:', parent);
+    if (!parent) return false;
+
+    const style = window.getComputedStyle(parent);
+
+    // Explicit height via inline or computed (not auto)
+    const hasExplicitHeight =
+        parent.style.height && parent.style.height !== 'auto';
+
+    // Check for flex/grid constraints
+    const isFlexOrGrid =
+        style.display.includes('flex') ||
+        style.display.includes('grid');
+
+    // Check if height is constrained via layout context
+    const hasConstrainedHeight =
+        style.height !== 'auto' &&
+        style.maxHeight !== 'none';
+
+    return hasExplicitHeight || (hasConstrainedHeight && isFlexOrGrid);
+};
+
+/**
  * Observes element size changes and forwards throttled updates to a .NET callback.
  * Automatically stops observing when the element is removed from the DOM.
  */


### PR DESCRIPTION
<!-- Describe your changes and what the purpose of them is. -->
<!-- If you made any visual changes, provide screenshots of before/after. If it has moving parts, please attach a high-quality video. -->

**Checklist:**
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [contribution guidelines](CONTRIBUTING.md)
- [x] My code follows the style of this project
- [x] I've added or updated relevant unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charts now properly handle invalid dimension values by falling back to defaults, ensuring correct sizing behavior in edge cases.

* **Improvements**
  * Enhanced responsive chart sizing to better detect and adapt to fixed-height parent containers, improving display consistency across different layout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->