### PR TITLE
Fix Chart Height Layout and Legend Overflow

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -224,4 +224,17 @@ public class ChartSizingTests : BunitTest
 
         comp.FindAll("div[style*='height:400px']").Should().BeEmpty();
     }
+
+    [Test]
+    public void MudChart_SvgWidthHeight_ShouldBe100Percent()
+    {
+        var series = new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20 } } };
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.ChartSeries, series));
+
+        var svg = comp.Find("svg");
+        svg.GetAttribute("width").Should().Be("100%");
+        svg.GetAttribute("height").Should().Be("100%");
+    }
 }

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor
@@ -6,7 +6,7 @@
 @typeparam TChartOptions
 
 <svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" 
-     width="@Width" height="@Height" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
+     width="100%" height="100%" viewBox="0 0 @ViewBoxWidth.ToStr() @ViewBoxHeight.ToStr()"
      style="@HoveredStylename">
     <Filters />
 

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -5,7 +5,7 @@
 @typeparam T
 @typeparam TChartOptions
 
-<svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" width="@Width" height="@Height" viewBox="0 0 @(ToS(Radius * 2)) @(ToS(Radius * 2))" style="@HoveredStylename">
+<svg @ref="_svgRef" @attributes="UserAttributes" class="@($"{ChartClass} mud-ltr")" width="100%" height="100%" viewBox="0 0 @(ToS(Radius * 2)) @(ToS(Radius * 2))" style="@HoveredStylename">
     <Filters />
 
     <g transform="translate(@Radius.ToStr(), @Radius.ToStr())">

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -10,7 +10,8 @@
     var series = _series.Where(x => x.Visible).ToList();
 }
 
-<svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" 
+<div @ref="_elementReference" @attributes="UserAttributes" class="@Classname">
+<svg class="mud-chart-heat mud-ltr"
      width="100%" height="100%" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
      style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
@@ -386,7 +387,5 @@
     }
 </svg>
 
-@if (CanHideSeries)
-{
-    <Legend T="T" Data="@_toggleLegend"></Legend>
-}
+<Legend T="T" Data="@_toggleLegend" ShowLegend="@CanHideSeries"></Legend>
+</div>

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -11,7 +11,7 @@
 }
 
 <svg @ref="_elementReference" @attributes="UserAttributes" class="mud-chart-heat mud-ltr" 
-     width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
+     width="100%" height="100%" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()"
      style="@HoveredStylename">
     @if (_options is { EnableSmoothGradient: true })
     {

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -8,8 +8,8 @@
     var glowName = $"glow_{Guid.NewGuid()}";
 }
 
-<div @ref="_elementReference" class="mud-chart-sankey" style="width:@Width; height:@Height">
-    <svg @attributes="UserAttributes" class="mud-chart-sankey mud-ltr" width="@Width" height="@Height" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()">
+<div @ref="_elementReference" class="mud-chart-sankey mud-chart" style="width:100%; height:100%">
+    <svg @attributes="UserAttributes" class="mud-chart-sankey mud-ltr" width="100%" height="100%" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()">
         <defs>
             @foreach (var edge in EdgePaths)
             {

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -8,8 +8,8 @@
     var glowName = $"glow_{Guid.NewGuid()}";
 }
 
-<div @ref="_elementReference" class="mud-chart-sankey mud-chart" style="width:100%; height:100%">
-    <svg @attributes="UserAttributes" class="mud-chart-sankey mud-ltr" width="100%" height="100%" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()">
+<div @ref="_elementReference" @attributes="UserAttributes" class="@Classname">
+    <svg class="mud-chart-sankey mud-ltr" width="100%" height="100%" viewBox="0 0 @_boundWidth.ToStr() @_boundHeight.ToStr()">
         <defs>
             @foreach (var edge in EdgePaths)
             {
@@ -89,9 +89,6 @@
         }
         @MudChartParent?.CustomGraphics
     </svg>
-</div>
 
-@if (CanHideSeries)
-{
-    <Legend T="T" Data="@_legend" />
-}
+    <Legend T="T" Data="@_legend" ShowLegend="@(CanHideSeries)" />
+</div>

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -1,10 +1,13 @@
 .mud-chart {
   display: flex;
-  min-height: fit-content;
-  min-width: fit-content;
+  width: 100%;
+  height: 100%;
 
   svg {
-    order: 2
+    order: 2;
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
   }
 
   &.mud-chart-legend-bottom {
@@ -36,6 +39,8 @@
       order: 3;
       min-width: fit-content;
       margin-left: 10px;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 
@@ -47,6 +52,8 @@
       order: 1;
       min-width: fit-content;
       margin-right: 10px;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 

--- a/src/MudBlazor/Styles/components/_charts.scss
+++ b/src/MudBlazor/Styles/components/_charts.scss
@@ -8,6 +8,8 @@
     flex: 1;
     min-height: 0;
     min-width: 0;
+    width: 100%;
+    height: 100%;
   }
 
   &.mud-chart-legend-bottom {


### PR DESCRIPTION
I have fixed the chart height issue where the legend was not accounted for in the total component height. 

Key changes:
1.  **CSS/SCSS Update:** Modified `.mud-chart` to use `display: flex`, `width: 100%`, and `height: 100%`. The underlying `svg` element now has `flex: 1`, `min-height: 0`, and `min-width: 0`, allowing it to share space with the legend within the container.
2.  **SVG Attribute Changes:** Updated `BaseRadialChart.razor`, `BaseAxisChart.razor`, `HeatMap.razor`, and `Sankey.razor` to set the SVG `width` and `height` attributes to `100%`. This ensures the SVG is sized by the flex container while the user's `@Width` and `@Height` parameters are still used for internal calculations and container sizing.
3.  **Sankey Component Fix:** Added the `mud-chart` class to the root `div` of the `Sankey` component to enable the same flexible layout.
4.  **Unit Tests:** Added a new test case `MudChart_SvgWidthHeight_ShouldBe100Percent` to `ChartSizingTests.cs` to verify that SVG elements are correctly configured with `100%` dimensions.
5.  **Visual Verification:** Verified the fix using Playwright screenshots, confirming that the chart and legend now stay within a fixed-height container without overflowing.

---
*PR created automatically by Jules for task [8683296064395079916](https://jules.google.com/task/8683296064395079916) started by @Anu6is*