### PR TITLE
Fix Radar Chart "Can Hide Series" for GroupByLabel mode

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartTests.cs
@@ -26,6 +26,53 @@ public class RadarChartTests : BunitTest
     }
 
     [Test]
+    public async Task RadarChart_CanHideSeries_GroupByLabel()
+    {
+        var chartSeries = new List<ChartSeries<double>>()
+        {
+            new () { Name = "Series 1", Data = new double[] { 90, 79, 72, 69 } },
+            new () { Name = "Series 2", Data = new double[] { 10, 41, 35, 51 } }
+        };
+        string[] xAxisLabels = { "Cat A", "Cat B", "Cat C", "Cat D" };
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Radar)
+            .Add(p => p.Height, "400px")
+            .Add(p => p.Width, "400px")
+            .Add(p => p.ChartSeries, chartSeries)
+            .Add(p => p.ChartLabels, xAxisLabels)
+            .Add(p => p.CanHideSeries, true)
+            .Add(p => p.ChartOptions, new RadarChartOptions { AggregationOption = AggregationOption.GroupByLabel })
+        );
+
+        // In GroupByLabel mode, legends should be "Cat A", "Cat B", "Cat C", "Cat D" (seriesData from GroupDataSet)
+        var seriesCheckboxes = comp.FindAll(".mud-checkbox-input");
+        seriesCheckboxes.Count.Should().Be(xAxisLabels.Length, "Number of checkboxes should match number of labels");
+
+        seriesCheckboxes[0].IsChecked().Should().BeTrue("Cat A should be initially visible");
+        seriesCheckboxes[1].IsChecked().Should().BeTrue("Cat B should be initially visible");
+
+        // Initial paths check
+        // In GroupByLabel mode, the "seriesData" contains one series per LABEL.
+        // So for 4 labels, there should be 4 paths.
+        // BUT wait, each "web" is actually composed of points from these grouped series?
+        // Let's re-read GenerateSvgPaths.
+        // It iterates over seriesData (which has 4 items if we have 4 labels).
+        // Each path is a polygon.
+
+        var seriesPaths = comp.FindAll("path.mud-chart-serie");
+        seriesPaths.Count.Should().Be(4, "Should have 4 paths (one per label) initially");
+
+        // Hide Cat A (the first checkbox)
+        await seriesCheckboxes[0].ChangeAsync(false);
+
+        // When Cat A is hidden, we expect its path to be removed.
+        // In GroupByLabel mode, there are 4 paths, one for each label.
+        // Clicking the first checkbox (Cat A) should hide the first path.
+        comp.FindAll("path.mud-chart-serie").Count.Should().Be(3, "One path should be hidden after unchecking Cat A");
+    }
+
+    [Test]
     public async Task RadarChart_Should_UpdateSelectedPointIndex_OnDataMarkerClick()
     {
         var seriesData = new double[] { 10, 20, 30 };

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -94,7 +94,6 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
 
         _paths.Clear();
         _legends.Clear();
-        HiddenIndices.Clear();
 
         if (MatchBoundsToSize && _elementSize is null)
         {

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -44,8 +44,6 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         var (seriesData, labelData) = GroupDataSet(ChartLabels ?? [], ChartSeries, ChartOptions!.AggregationOption == AggregationOption.GroupByDataSet);
         var numAxes = labelData.Length;
 
-        BuildLegends([.. seriesData.Select(x => x.Name)]);
-
         var angleStep = 2 * Math.PI / numAxes;
         var currentAngle = (-Math.PI / 2) + (ChartOptions.AngleOffset * (Math.PI / 180)); // Convert offset to radians
         var radius = CalculateRadius();
@@ -66,6 +64,8 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
 
         GenerateAxisLines(numAxes, angleStep, currentAngle, radius, labelData);
         GenerateSvgPaths(seriesData, normalizedData, numAxes, angleStep, currentAngle, radius, axisMaxValue);
+
+        BuildLegends([.. seriesData.Select(x => x.Name)]);
     }
 
     private bool HasValidData() =>


### PR DESCRIPTION
This PR fixes an issue where legend checkboxes were non-functional for Radar charts, particularly when the `GroupByLabel` aggregation option was enabled.

The root cause was twofold:
1. `MudRadialChartBase` was clearing the `HiddenIndices` collection during every `OnParametersSet` call, causing any visibility changes made via the legend to be immediately lost.
2. In the `Radar` component, `BuildLegends` was being called before the SVG paths were generated, meaning the legend could not correctly determine which series should be visible based on the presence of paths.

The fix involves:
- Removing `HiddenIndices.Clear()` from `MudRadialChartBase.OnParametersSet`.
- Reordering calls in `Radar.RebuildChart` so that `BuildLegends` occurs after `GenerateSvgPaths`.
- Adding a regression test `RadarChart_CanHideSeries_GroupByLabel` to ensure continued functionality.

---
*PR created automatically by Jules for task [4066006102792143873](https://jules.google.com/task/4066006102792143873) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where hidden series state was incorrectly reset when radar chart parameters changed.
  * Improved legend generation timing to ensure proper chart rendering when using series hiding functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->