### PR TITLE
Fix MudChart visual jump on percentage height

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ChartSizingTests.cs
@@ -200,9 +200,9 @@ public class ChartSizingTests : BunitTest
 
         await comp.WaitForAssertionAsync(() =>
         {
-            var fallbackDiv = comp.Find("div[style*='height:400px']");
+            var fallbackDiv = comp.Find("div[data-fallback='true']");
             fallbackDiv.Should().NotBeNull();
-            fallbackDiv.GetAttribute("style").Should().Contain("height:400px");
+            fallbackDiv.GetAttribute("style").Should().Contain("height: 400px");
         });
     }
 
@@ -222,6 +222,32 @@ public class ChartSizingTests : BunitTest
 
         await comp.WaitForAssertionAsync(() => Context.JSInterop.Invocations["hasDefinedParentHeight"].Should().HaveCount(1));
 
-        comp.FindAll("div[style*='height:400px']").Should().BeEmpty();
+        comp.FindAll("div[data-fallback='true']").Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task MudChart_ShouldBeHiddenInitially_WhenMeasuring()
+    {
+        var series = new List<ChartSeries<double>> { new() { Data = new double[] { 10, 20 } } };
+
+        // Setup JS interop
+        var jsInterop = Context.JSInterop.Setup<bool>("hasDefinedParentHeight", _ => true);
+        jsInterop.SetResult(false);
+
+        var comp = Context.Render<MudChart<double>>(parameters => parameters
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.MatchBoundsToSize, true)
+            .Add(p => p.Height, "100%")
+            .Add(p => p.ChartSeries, series));
+
+        // Wait for it to be in measuring state or already finished
+        // Note: in bUnit, first render might be synchronous or very fast.
+        // If we can't catch the hidden state, we can at least verify that it transitions correctly.
+
+        await comp.WaitForAssertionAsync(() =>
+        {
+            // It should eventually not be measuring anymore
+            comp.FindAll("div[data-measuring]").Should().BeEmpty();
+        });
     }
 }

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -9,19 +9,13 @@
 @attribute [CascadingTypeParameter(nameof(T))]
 
 <CascadingValue Value="@this" IsFixed="true">
-    @if (_hasFixedParent is null)
-    {
-        <div style="height: @(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width); visibility: hidden;" data-measuring>
-            @ChartContainer
-        </div>
-    }
-    else if (_hasFixedParent.Value)
+    @if (_hasFixedParent is true)
     {
         @ChartContainer
     }
     else
     {
-        <div style="height: @(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width);" data-fallback="@(HasPercentageHeight() ? "true" : "false")">
+        <div style="@GetWrapperStyle()" @attributes="@GetWrapperAttributes()">
             @ChartContainer
         </div>
     }
@@ -38,7 +32,7 @@
     private RenderFragment ChartContainer => @<div @ref="_containerRef"
                                                    @attributes="UserAttributes"
                                                    class="@Classname"
-                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {@Height};")"
+                                                   style="@($"{Style}; width: {(MatchBoundsToSize ? "100%" : @Width)}; height: {@Height}; {(MatchBoundsToSize && _hasFixedParent is null ? "visibility: hidden;" : "")}")"
                                                    dir="ltr">
         @ChartContent
     </div>;

--- a/src/MudBlazor/Components/Chart/MudChart.razor
+++ b/src/MudBlazor/Components/Chart/MudChart.razor
@@ -1,4 +1,4 @@
-﻿@using MudBlazor.Charts
+@using MudBlazor.Charts
 @using System.Numerics
 
 @namespace MudBlazor
@@ -9,13 +9,19 @@
 @attribute [CascadingTypeParameter(nameof(T))]
 
 <CascadingValue Value="@this" IsFixed="true">
-    @if (_hasFixedParent)
+    @if (_hasFixedParent is null)
+    {
+        <div style="height: @(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width); visibility: hidden;" data-measuring>
+            @ChartContainer
+        </div>
+    }
+    else if (_hasFixedParent.Value)
     {
         @ChartContainer
     }
     else
     {
-        <div style="height:@(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width);">
+        <div style="height: @(HasPercentageHeight() ? FallbackHeight : Height); width: @(MatchBoundsToSize ? "100%" : Width);" data-fallback="@(HasPercentageHeight() ? "true" : "false")">
             @ChartContainer
         </div>
     }

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -17,7 +17,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = null!;
 
-    private bool _hasFixedParent = true;
+    private bool? _hasFixedParent;
 
     private ChartType? _chartType;
     private IChartOptions? _chartOptions;
@@ -49,7 +49,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
 
     protected override void OnAfterRender(bool firstRender)
     {
-        if (firstRender && ChartReference is not null)
+        if (firstRender && ChartReference is not null && _hasFixedParent is not null)
         {
             StateHasChanged();
         }
@@ -61,19 +61,21 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (!MatchBoundsToSize)
+        if (_hasFixedParent is not null)
         {
             return;
         }
 
-        if (firstRender && HasPercentageHeight())
+        if (MatchBoundsToSize && firstRender && HasPercentageHeight())
         {
             _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
-
-            if (!_hasFixedParent)
-            {
-                StateHasChanged();
-            }
+            StateHasChanged();
+        }
+        else
+        {
+            _hasFixedParent = true;
+            // No need to call StateHasChanged if we are already showing it in the correct size (fixed pixels)
+            // or if we're not matching bounds to size.
         }
     }
 

--- a/src/MudBlazor/Components/Chart/MudChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/MudChart.razor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) MudBlazor 2021
+// Copyright (c) MudBlazor 2021
 // MudBlazor licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -45,11 +45,16 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
             ChartOptions options => GetChartTypeOptions(options),
             _ => ChartOptions
         };
+
+        if (_hasFixedParent is null && (!MatchBoundsToSize || !HasPercentageHeight()))
+        {
+            _hasFixedParent = true;
+        }
     }
 
     protected override void OnAfterRender(bool firstRender)
     {
-        if (firstRender && ChartReference is not null && _hasFixedParent is not null)
+        if (firstRender && ChartReference is not null)
         {
             StateHasChanged();
         }
@@ -61,12 +66,12 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (_hasFixedParent is not null)
+        if (_hasFixedParent is not null || !firstRender)
         {
             return;
         }
 
-        if (MatchBoundsToSize && firstRender && HasPercentageHeight())
+        if (MatchBoundsToSize && HasPercentageHeight())
         {
             _hasFixedParent = await JsRuntime.InvokeAsync<bool>("hasDefinedParentHeight", _containerRef);
             StateHasChanged();
@@ -74,8 +79,7 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
         else
         {
             _hasFixedParent = true;
-            // No need to call StateHasChanged if we are already showing it in the correct size (fixed pixels)
-            // or if we're not matching bounds to size.
+            StateHasChanged();
         }
     }
 
@@ -112,4 +116,29 @@ public partial class MudChart<T> where T : struct, INumber<T>, IMinMaxValue<T>, 
     };
 
     public override void RebuildChart() => ChartReference?.RebuildChart();
+
+    private string GetWrapperStyle()
+    {
+        if (_hasFixedParent is true)
+        {
+            return string.Empty;
+        }
+
+        var height = HasPercentageHeight() ? FallbackHeight : Height;
+        var width = MatchBoundsToSize ? "100%" : Width;
+
+        return $"height: {height}; width: {width};";
+    }
+
+    private IEnumerable<KeyValuePair<string, object>> GetWrapperAttributes()
+    {
+        if (_hasFixedParent is null)
+        {
+            yield return new KeyValuePair<string, object>("data-measuring", "");
+        }
+        else if (_hasFixedParent is false)
+        {
+            yield return new KeyValuePair<string, object>("data-fallback", HasPercentageHeight() ? "true" : "false");
+        }
+    }
 }


### PR DESCRIPTION
This change addresses a common issue where `MudChart` components using percentage heights (like the default 80%) would visually shrink or jump after the initial render when placed in a container without a defined height.

The fix involves:
1.  **3-State Rendering:** The chart now has a hidden "measuring" state. During this phase, it renders with `visibility: hidden` and the `FallbackHeight` (400px) if a percentage height is used.
2.  **Parent Detection:** JavaScript (`hasDefinedParentHeight`) is invoked to detect if a fixed-height parent exists.
3.  **Correct Sizing:** Once detected, if no fixed parent exists, the chart uses the 400px fallback wrapper. Crucially, the internal chart still receives the original `Height` parameter (e.g., 80%), so it correctly renders at 320px within the 400px wrapper, matching the user's expectation without the initial 400px flash.
4.  **No Regressions:** For fixed pixel heights (e.g., `Height="300px"`), the measuring phase is bypassed, and no unnecessary re-renders occur.
5.  **Testability:** Added `data-fallback` and `data-measuring` attributes to make the component's state easier to verify in unit tests.
6.  **Unit Tests:** All tests in `ChartSizingTests.cs` are passing, including a new test for the measuring transition.

---
*PR created automatically by Jules for task [9754628695087571340](https://jules.google.com/task/9754628695087571340) started by @Anu6is*