### PR TITLE
Fix ScatterPlot Rendering and Scaling

### DIFF
--- a/src/MudBlazor.UnitTests/Components/Charts/ScatterPlotChartTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ScatterPlotChartTests.cs
@@ -324,9 +324,9 @@ namespace MudBlazor.UnitTests.Charts
                 {
                     ChartPalette = _palette,
                     ShowToolTips = true,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -350,9 +350,9 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ScatterPlotChartOptions
                 {
                     ChartPalette = _palette,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -372,9 +372,9 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ScatterPlotChartOptions
                 {
                     ChartPalette = _palette,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride
+                        [lineSeries] = new ScatterSeriesDisplayOverride
                         {
                             ScatterSeriesType = ScatterSeriesType.Line,
                             StrokeOpacity = 0.5
@@ -398,9 +398,9 @@ namespace MudBlazor.UnitTests.Charts
                 {
                     ChartPalette = _palette,
                     LineStrokeWidth = 2,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -422,9 +422,9 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartOptions, new ScatterPlotChartOptions
                 {
                     XAxisTicks = 20,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -444,9 +444,9 @@ namespace MudBlazor.UnitTests.Charts
                 .Add(p => p.ChartSeries, series)
                 .Add(p => p.ChartOptions, new ScatterPlotChartOptions
                 {
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -518,9 +518,8 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
-        public void ScatterPlotShowDataLabelsRequiresShowToolTips()
+        public void ScatterPlotShowDataLabelsWorksWhenShowToolTipsIsFalse()
         {
-            // ShowDataLabels iterates ChartDataPoints which is only populated when ShowToolTips is true
             var series = new List<ChartSeries<double>>
             {
                 new() { Name = "S1", Data = Points((10, 20), (30, 40)) }
@@ -534,8 +533,8 @@ namespace MudBlazor.UnitTests.Charts
                     ShowDataLabels = true,
                 }));
 
-            comp.FindAll("text.mud-chart-data-label").Count.Should().Be(0,
-                because: "data label entries are only generated when ShowToolTips is true");
+            comp.FindAll("text.mud-chart-data-label").Count.Should().Be(2,
+                because: "data labels should now work even when tooltips are disabled");
         }
 
         [Test]
@@ -551,9 +550,9 @@ namespace MudBlazor.UnitTests.Charts
                     ChartPalette = _palette,
                     ShowToolTips = true,
                     ShowDataLabels = true,
-                    SeriesDisplayOverrides = new Dictionary<IChartSeries, SeriesDisplayOverride>
+                    SeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>
                     {
-                        [lineSeries] = new SeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
+                        [lineSeries] = new ScatterSeriesDisplayOverride { ScatterSeriesType = ScatterSeriesType.Line }
                     }
                 }));
 
@@ -934,7 +933,7 @@ namespace MudBlazor.UnitTests.Charts
         }
 
         [Test]
-        public void ScatterPlotNoTooltipWhenShowToolTipsFalse()
+        public void ScatterPlotRendersMarkersWhenShowToolTipsFalse()
         {
             var series = new List<ChartSeries<double>>
             {
@@ -949,8 +948,9 @@ namespace MudBlazor.UnitTests.Charts
                 }));
 
             comp.FindAll("g.svg-tooltip").Count.Should().Be(0);
-            // No hoverable circles are rendered when ShowToolTips is false
-            comp.FindAll("circle.mud-chart-point").Count.Should().Be(0);
+            // Only the visible marker circle should be rendered (1 point = 1 circle)
+            // The hoverable circle should be gated by ShowToolTips
+            comp.FindAll("circle.mud-chart-point").Count.Should().Be(1, because: "markers should render even when tooltips are disabled");
         }
 
         [Test]

--- a/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseAxisChart.razor.cs
@@ -219,6 +219,13 @@ public partial class BaseAxisChart<T, TChartOptions> : MudComponentBase
             .Build();
 
     /// <summary>
+    /// Converts a double value to its string representation.
+    /// </summary>
+    /// <param name="value">The double value to convert.</param>
+    /// <returns>The string representation of the double value.</returns>
+    protected string ToS(double value) => value.ToStr();
+
+    /// <summary>
     /// Called after the component has been rendered.
     /// </summary>
     /// <param name="firstRender">True if this is the first time the component is rendering; otherwise, false.</param>

--- a/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultAxisLineChartOptions.cs
@@ -64,34 +64,4 @@ public abstract class DefaultAxisLineChartOptions : DefaultAxisChartOptions, IAx
     }
 
     private Dictionary<IChartSeries, SeriesDisplayOverride> _seriesDisplayOverrides = new(ChartDataSetComparer.Instance);
-
-    /// <summary>
-    /// A comparer for chart data series.
-    /// </summary>
-    private sealed class ChartDataSetComparer : IEqualityComparer<IChartSeries>
-    {
-        /// <summary>
-        /// The singleton instance of the comparer.
-        /// </summary>
-        public static readonly ChartDataSetComparer Instance = new();
-
-        private ChartDataSetComparer() { }
-
-        /// <summary>
-        /// Determines whether the specified objects are equal.
-        /// </summary>
-        /// <param name="x">The first object to compare.</param>
-        /// <param name="y">The second object to compare.</param>
-        /// <returns>True if the specified objects are equal; otherwise, false.</returns>
-        public bool Equals(IChartSeries? x, IChartSeries? y)
-            => x?.Name == y?.Name && x?.Visible == y?.Visible;
-
-        /// <summary>
-        /// Returns a hash code for the specified object.
-        /// </summary>
-        /// <param name="obj">The object for which a hash code is to be returned.</param>
-        /// <returns>A hash code for the specified object.</returns>
-        public int GetHashCode(IChartSeries obj)
-            => obj.Name?.GetHashCode() ?? 0;
-    }
 }

--- a/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IAxisLineChartOptions.cs
@@ -81,30 +81,4 @@ public record SeriesDisplayOverride
     /// The fill opacity for the series, used when the display type is 'Area'.
     /// </summary>
     public double FillOpacity { get; set; } = 0.4;
-
-    /// <summary>
-    /// Determines how this series is rendered on a scatter plot chart.
-    /// Defaults to <see cref="ScatterSeriesType.Points"/>.
-    /// </summary>
-    /// <remarks>
-    /// Set to <see cref="ScatterSeriesType.Line"/> to render this series as a line (e.g. a regression line)
-    /// overlaid on scatter point series.
-    /// </remarks>
-    public ScatterSeriesType ScatterSeriesType { get; set; } = ScatterSeriesType.Points;
-}
-
-/// <summary>
-/// Determines how a series is rendered on a <see cref="Charts.ScatterPlot{T}"/> chart.
-/// </summary>
-public enum ScatterSeriesType
-{
-    /// <summary>
-    /// Renders data as individual scatter point markers (default).
-    /// </summary>
-    Points,
-
-    /// <summary>
-    /// Renders data as a continuous line, useful for regression lines or trend overlays.
-    /// </summary>
-    Line
 }

--- a/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudAxisLineChartBase.cs
@@ -203,13 +203,13 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
     /// <param name="horizontalSpace">The horizontal space between points.</param>
     /// <param name="verticalSpace">The vertical space between points.</param>
     /// <returns>A tuple containing the first X, first Y, and last X coordinates.</returns>
-    protected (double firstX, double firstY, double lastX) GenerateStraightLines(int seriesIndex,
-                                                                                 StringBuilder chartLine,
-                                                                                 List<SvgCircle> chartDataCircles,
-                                                                                 int lowestHorizontalLine,
-                                                                                 T gridYUnits,
-                                                                                 double horizontalSpace,
-                                                                                 double verticalSpace)
+    protected virtual (double firstX, double firstY, double lastX) GenerateStraightLines(int seriesIndex,
+                                                                                         StringBuilder chartLine,
+                                                                                         List<SvgCircle> chartDataCircles,
+                                                                                         int lowestHorizontalLine,
+                                                                                         T gridYUnits,
+                                                                                         double horizontalSpace,
+                                                                                         double verticalSpace)
     {
         double firstPointX = 0, firstPointY = 0, lastPointX = 0;
 
@@ -439,7 +439,7 @@ public abstract class MudAxisLineChartBase<T, TOptions> : MudAxisChartBase<T, TO
     /// </summary>
     /// <param name="series">The chart series.</param>
     /// <returns>The series display override, or null if not found.</returns>
-    protected SeriesDisplayOverride? GetSeriesDisplayOverride(ChartSeries<T> series)
+    protected virtual SeriesDisplayOverride? GetSeriesDisplayOverride(ChartSeries<T> series)
     {
         return ChartOptions?.SeriesDisplayOverrides?.TryGetValue(series, out var overrideData) is true
             ? overrideData

--- a/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
+++ b/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
@@ -45,7 +45,7 @@
 
     private bool IsLineSeries(int seriesIndex) =>
         seriesIndex >= 0 && seriesIndex < Series.Count &&
-        GetSeriesDisplayOverride(Series[seriesIndex])?.ScatterSeriesType == ScatterSeriesType.Line;
+        GetSeriesDisplayOverride(Series[seriesIndex]) is ScatterSeriesDisplayOverride { ScatterSeriesType: ScatterSeriesType.Line };
 
     private RenderFragment RenderScatterPoints() => builder =>
     {
@@ -74,7 +74,7 @@
                     builder.AddAttribute(seq++, "onclick", EventCallback.Factory.Create(this, () => SetSelectedIndexAsync(index)));
                     builder.AddAttribute(seq++, "fill", color);
                     builder.AddAttribute(seq++, "stroke", color);
-                    builder.AddAttribute(seq++, "stroke-width", DataPointStroke);
+                    builder.AddAttribute(seq++, "stroke-width", DataPointStroke.ToStr());
                     builder.AddAttribute(seq++, "cx", item.CX.ToStr());
                     builder.AddAttribute(seq++, "cy", item.CY.ToStr());
                     builder.AddAttribute(seq++, "r", PointRadius.ToStr());
@@ -96,19 +96,22 @@
                 }
 
                 // Hoverable target (larger, shows on hover, carries mouse events)
-                builder.OpenElement(seq++, "circle");
-                builder.AddAttribute(seq++, "class", "mud-chart-serie mud-chart-point");
-                builder.AddAttribute(seq++, "onclick", EventCallback.Factory.Create(this, () => SetSelectedIndexAsync(index)));
-                builder.AddAttribute(seq++, "fill", isHovered ? color : string.Empty);
-                builder.AddAttribute(seq++, "stroke", color);
-                builder.AddAttribute(seq++, "stroke-width", DataPointStroke);
-                builder.AddAttribute(seq++, "opacity", isHovered ? 1 : 0);
-                builder.AddAttribute(seq++, "cx", item.CX.ToStr());
-                builder.AddAttribute(seq++, "cy", item.CY.ToStr());
-                builder.AddAttribute(seq++, "r", PointHoverRadius.ToStr());
-                builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create<MouseEventArgs>(this, e => OnDataPointMouseOver(e, item)));
-                builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnDataPointMouseOut));
-                builder.CloseElement();
+                if (ChartOptions?.ShowToolTips is true)
+                {
+                    builder.OpenElement(seq++, "circle");
+                    builder.AddAttribute(seq++, "class", "mud-chart-serie mud-chart-point");
+                    builder.AddAttribute(seq++, "onclick", EventCallback.Factory.Create(this, () => SetSelectedIndexAsync(index)));
+                    builder.AddAttribute(seq++, "fill", isHovered ? color : string.Empty);
+                    builder.AddAttribute(seq++, "stroke", color);
+                    builder.AddAttribute(seq++, "stroke-width", DataPointStroke.ToStr());
+                    builder.AddAttribute(seq++, "opacity", isHovered ? "1" : "0");
+                    builder.AddAttribute(seq++, "cx", item.CX.ToStr());
+                    builder.AddAttribute(seq++, "cy", item.CY.ToStr());
+                    builder.AddAttribute(seq++, "r", PointHoverRadius.ToStr());
+                    builder.AddAttribute(seq++, "onmouseover", EventCallback.Factory.Create<MouseEventArgs>(this, e => OnDataPointMouseOver(e, item)));
+                    builder.AddAttribute(seq++, "onmouseout", EventCallback.Factory.Create(this, OnDataPointMouseOut));
+                    builder.CloseElement();
+                }
             }
         }
 

--- a/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor.cs
@@ -108,22 +108,35 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
             ? T.CreateSaturating(ChartOptions.XAxisTicks)
             : T.CreateSaturating(20);
 
-        var xValues = Series
+        var points = Series
             .Where(s => s.Visible)
             .SelectMany(s => s.Data.Points)
-            .Select(p => p.X)
-            .OfType<T>()
             .ToArray();
 
-        if (xValues.Length == 0)
+        if (points.Length == 0)
         {
             lowestVerticalLine = 0;
             numVerticalLines = 1;
             return;
         }
 
-        var minX = xValues.Min();
-        var maxX = xValues.Max();
+        var xValues = points
+            .Select(p => p.X)
+            .OfType<T>()
+            .ToArray();
+
+        T minX, maxX;
+        if (xValues.Length < points.Length)
+        {
+            // If any points have non-numeric X, use indices for all points to ensure a consistent scale
+            minX = T.Zero;
+            maxX = T.CreateSaturating(Series.Max(s => s.Data.Points.Count) - 1);
+        }
+        else
+        {
+            minX = xValues.Min();
+            maxX = xValues.Max();
+        }
 
         lowestVerticalLine = (int)Math.Floor(double.CreateSaturating(minX) / double.CreateSaturating(gridXUnits));
         var highestVerticalLine = (int)Math.Ceiling(double.CreateSaturating(maxX) / double.CreateSaturating(gridXUnits));
@@ -152,6 +165,13 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
         return (TReturn)Convert.ChangeType(Series[seriesIndex].Data.Points[dataPointIndex].Y, typeof(TReturn));
     }
 
+    protected override SeriesDisplayOverride? GetSeriesDisplayOverride(ChartSeries<T> series)
+    {
+        return ChartOptions?.SeriesDisplayOverrides?.TryGetValue(series, out var overrideData) is true
+            ? overrideData
+            : null;
+    }
+
     protected override string GetLabelXValue(int seriesIndex, int dataPointIndex)
     {
         var x = Series[seriesIndex].Data.Points[dataPointIndex].X;
@@ -162,7 +182,7 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
                 : xVal.ToString(null, null);
         }
 
-        return x?.ToString() ?? string.Empty;
+        return dataPointIndex.ToString();
     }
 
     protected override (double x, double y) GetXYForDataPoint(int seriesIndex, int dataPointIndex, int lowestHorizontalLine, T gridYUnits, double horizontalSpace, double verticalSpace)
@@ -182,11 +202,64 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
         }
         else
         {
-            // Fallback: evenly distribute by index
-            screenX = HorizontalStartSpace + (dataPointIndex * horizontalSpace);
+            // Fallback: use index mapped through the X-axis scale
+            var gridValueX = ((double.CreateSaturating(dataPointIndex) / double.CreateSaturating(_gridXUnits)) - _lowestVerticalLine) * _horizontalSpacePerXUnit;
+            screenX = HorizontalStartSpace + gridValueX;
         }
 
         return (screenX, screenY);
+    }
+
+    protected override (double firstX, double firstY, double lastX) GenerateStraightLines(int seriesIndex,
+        System.Text.StringBuilder chartLine,
+        List<SvgCircle> chartDataCircles,
+        int lowestHorizontalLine,
+        T gridYUnits,
+        double horizontalSpace,
+        double verticalSpace)
+    {
+        double firstPointX = 0, firstPointY = 0, lastPointX = 0;
+
+        var series = Series[seriesIndex];
+        var dataLength = series.Data.Points.Count;
+
+        for (var j = 0; j < dataLength; j++)
+        {
+            var (x, y) = GetXYForDataPoint(seriesIndex, j, lowestHorizontalLine, gridYUnits, horizontalSpace, verticalSpace);
+
+            if (j == 0)
+            {
+                chartLine.Append("M ");
+                firstPointX = x;
+                firstPointY = y;
+            }
+            else
+            {
+                chartLine.Append(" L ");
+            }
+
+            if (j == dataLength - 1)
+            {
+                lastPointX = x;
+            }
+
+            chartLine.Append(Utilities.StringHelpers.ToS(x));
+            chartLine.Append(' ');
+            chartLine.Append(Utilities.StringHelpers.ToS(y));
+
+            chartDataCircles.Add(new SvgCircle
+            {
+                Index = seriesIndex,
+                CX = x,
+                CY = y,
+                LabelX = x,
+                LabelXValue = GetLabelXValue(seriesIndex, j),
+                LabelY = y,
+                LabelYValue = GetDataValueAsString(seriesIndex, j)
+            });
+        }
+
+        return (firstPointX, firstPointY, lastPointX);
     }
 
     internal override ILineInterpolator CreateInterpolator(int seriesIndex, int lowestHorizontalLine, T gridYUnits, double horizontalSpace, double verticalSpace)

--- a/src/MudBlazor/Components/Chart/Models/ChartDataSetComparer.cs
+++ b/src/MudBlazor/Components/Chart/Models/ChartDataSetComparer.cs
@@ -1,0 +1,35 @@
+// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace MudBlazor.Charts;
+
+/// <summary>
+/// A comparer for chart data series.
+/// </summary>
+internal sealed class ChartDataSetComparer : IEqualityComparer<IChartSeries>
+{
+    /// <summary>
+    /// The singleton instance of the comparer.
+    /// </summary>
+    public static readonly ChartDataSetComparer Instance = new();
+
+    private ChartDataSetComparer() { }
+
+    /// <summary>
+    /// Determines whether the specified objects are equal.
+    /// </summary>
+    /// <param name="x">The first object to compare.</param>
+    /// <param name="y">The second object to compare.</param>
+    /// <returns>True if the specified objects are equal; otherwise, false.</returns>
+    public bool Equals(IChartSeries? x, IChartSeries? y)
+        => x?.Name == y?.Name && x?.Visible == y?.Visible;
+
+    /// <summary>
+    /// Returns a hash code for the specified object.
+    /// </summary>
+    /// <param name="obj">The object for which a hash code is to be returned.</param>
+    /// <returns>A hash code for the specified object.</returns>
+    public int GetHashCode(IChartSeries obj)
+        => obj.Name?.GetHashCode() ?? 0;
+}

--- a/src/MudBlazor/Components/Chart/Models/Options/ScatterPlotChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/ScatterPlotChartOptions.cs
@@ -11,6 +11,30 @@ namespace MudBlazor;
 /// </summary>
 public class ScatterPlotChartOptions : DefaultAxisLineChartOptions, IAxisLineChartOptions
 {
+    private Dictionary<IChartSeries, ScatterSeriesDisplayOverride> _scatterSeriesDisplayOverrides = new(ChartDataSetComparer.Instance);
+
+    /// <summary>
+    /// Optional per-series display overrides for scatter plot charts.
+    /// </summary>
+    public new IDictionary<IChartSeries, ScatterSeriesDisplayOverride> SeriesDisplayOverrides
+    {
+        get => _scatterSeriesDisplayOverrides;
+        set => _scatterSeriesDisplayOverrides = new Dictionary<IChartSeries, ScatterSeriesDisplayOverride>(value, ChartDataSetComparer.Instance);
+    }
+
+    /// <inheritdoc />
+    IDictionary<IChartSeries, SeriesDisplayOverride> IAxisLineChartOptions.SeriesDisplayOverrides
+    {
+        get => _scatterSeriesDisplayOverrides.ToDictionary(x => x.Key, x => (SeriesDisplayOverride)x.Value, ChartDataSetComparer.Instance);
+        set => _scatterSeriesDisplayOverrides = value.ToDictionary(x => x.Key, x => x.Value is ScatterSeriesDisplayOverride s ? s : new ScatterSeriesDisplayOverride
+        {
+            LineDisplayType = x.Value.LineDisplayType,
+            InterpolationOption = x.Value.InterpolationOption,
+            StrokeOpacity = x.Value.StrokeOpacity,
+            FillOpacity = x.Value.FillOpacity
+        }, ChartDataSetComparer.Instance);
+    }
+
     /// <summary>
     /// The radius of each data point marker, in pixels.
     /// </summary>
@@ -59,4 +83,36 @@ public class ScatterPlotChartOptions : DefaultAxisLineChartOptions, IAxisLineCha
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
         ChartPalette = options.ChartPalette,
     };
+}
+
+/// <summary>
+/// Represents display overrides for a specific series in a scatter plot chart.
+/// </summary>
+public record ScatterSeriesDisplayOverride : SeriesDisplayOverride
+{
+    /// <summary>
+    /// Determines how this series is rendered on a scatter plot chart.
+    /// Defaults to <see cref="ScatterSeriesType.Points"/>.
+    /// </summary>
+    /// <remarks>
+    /// Set to <see cref="ScatterSeriesType.Line"/> to render this series as a line (e.g. a regression line)
+    /// overlaid on scatter point series.
+    /// </remarks>
+    public ScatterSeriesType ScatterSeriesType { get; set; } = ScatterSeriesType.Points;
+}
+
+/// <summary>
+/// Determines how a series is rendered on a <see cref="Charts.ScatterPlot{T}"/> chart.
+/// </summary>
+public enum ScatterSeriesType
+{
+    /// <summary>
+    /// Renders data as individual scatter point markers (default).
+    /// </summary>
+    Points,
+
+    /// <summary>
+    /// Renders data as a continuous line, useful for regression lines or trend overlays.
+    /// </summary>
+    Line
 }


### PR DESCRIPTION
This change addresses several issues with the `ScatterPlot` component in MudBlazor:

1. **Tooltip Dependency**: Previously, scatter points and labels would only render if `ShowToolTips` was enabled because they relied on the `ChartDataPoints` collection, which was only populated when tooltips were on. This has been fixed by overriding `GenerateStraightLines` in `ScatterPlot` to always populate data points, while still gating the actual interactive hover targets in the Razor markup.

2. **X-axis Scaling for Non-Numeric Values**: Scatter plots now detect if any visible points have non-numeric or missing X values. In such cases, the component automatically switches to a consistent index-based scale for the entire chart, ensuring points are distributed correctly within bounds instead of being rendered outside the SVG area.

3. **Options Refactoring**: `ScatterSeriesType` (used to toggle between points and lines for a series) has been moved out of the base `SeriesDisplayOverride` and into a new `ScatterSeriesDisplayOverride` record. This is managed via a shadowed `SeriesDisplayOverrides` property in `ScatterPlotChartOptions`, keeping the base line chart options cleaner.

4. **Formatting Improvements**: Several numeric SVG attributes that were previously passed as raw doubles (using current culture) are now correctly formatted using `ToStr()` (invariant culture), preventing rendering issues in locales that use commas as decimal separators.

5. **Extensibility**: `MudAxisLineChartBase` methods `GenerateStraightLines` and `GetSeriesDisplayOverride` are now `virtual`, allowing specialized charts like `ScatterPlot` to customize their behavior without modifying the base logic.

Unit tests have been updated and all 46 tests for `ScatterPlot` are passing.

---
*PR created automatically by Jules for task [1840564619799101567](https://jules.google.com/task/1840564619799101567) started by @Anu6is*