### PR TITLE
Fix Radar Chart Scaling and Add Axis Customization

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -26,7 +26,7 @@
                     <ul>
                         <li><CodeInline>ShowGridLines</CodeInline>, <CodeInline>GridLevels</CodeInline>, <CodeInline>GridLineColor</CodeInline>: Control the appearance of the grid.</li>
                         <li><CodeInline>ShowAxisLabels</CodeInline>, <CodeInline>AxisLineColor</CodeInline>, <CodeInline>AxisLineWidth</CodeInline>: Customize the axes.</li>
-                        <li><CodeInline>YAxisSuggestedMax</CodeInline>, <CodeInline>YAxisFormat</CodeInline>, <CodeInline>YAxisToStringFunc</CodeInline>: Control axis scaling and label formatting.</li>
+                        <li><CodeInline>AxisSuggestedMax</CodeInline>, <CodeInline>AxisFormat</CodeInline>, <CodeInline>AxisToStringFunc</CodeInline>: Control axis scaling and label formatting.</li>
                         <li><CodeInline>FillOpacity</CodeInline>, <CodeInline>StrokeWidth</CodeInline>: Adjust the appearance of the data series.</li>
                         <li><CodeInline>ShowDataMarkers</CodeInline>, <CodeInline>DataPointRadius</CodeInline>: Display markers for each data point.</li>
                         <li><CodeInline>AngleOffset</CodeInline>: Rotates the entire chart.</li>

--- a/src/MudBlazor.Docs/Pages/Components/Charts/RadarChartPage.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Charts/RadarChartPage.razor
@@ -26,6 +26,7 @@
                     <ul>
                         <li><CodeInline>ShowGridLines</CodeInline>, <CodeInline>GridLevels</CodeInline>, <CodeInline>GridLineColor</CodeInline>: Control the appearance of the grid.</li>
                         <li><CodeInline>ShowAxisLabels</CodeInline>, <CodeInline>AxisLineColor</CodeInline>, <CodeInline>AxisLineWidth</CodeInline>: Customize the axes.</li>
+                        <li><CodeInline>YAxisSuggestedMax</CodeInline>, <CodeInline>YAxisFormat</CodeInline>, <CodeInline>YAxisToStringFunc</CodeInline>: Control axis scaling and label formatting.</li>
                         <li><CodeInline>FillOpacity</CodeInline>, <CodeInline>StrokeWidth</CodeInline>: Adjust the appearance of the data series.</li>
                         <li><CodeInline>ShowDataMarkers</CodeInline>, <CodeInline>DataPointRadius</CodeInline>: Display markers for each data point.</li>
                         <li><CodeInline>AngleOffset</CodeInline>: Rotates the entire chart.</li>

--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/RadarChartScalingTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/RadarChartScalingTest.razor
@@ -1,0 +1,26 @@
+@namespace MudBlazor.UnitTests.Viewer.TestComponents.Charts
+
+<MudChart ChartType="ChartType.Radar"
+          ChartSeries="@_series"
+          ChartLabels="@_labels"
+          ChartOptions="@_options"
+          Width="400px"
+          Height="400px" />
+
+<MudChart ChartType="ChartType.Radar"
+          ChartSeries="@_series"
+          ChartLabels="@_labels"
+          ChartOptions="@_optionsGrid6"
+          Width="400px"
+          Height="400px"
+          id="radar-grid-6" />
+
+@code {
+    private List<ChartSeries<double>> _series = new()
+    {
+        new ChartSeries<double> { Name = "Series 1", Data = new double[] { 5, 5, 5, 5, 5 } }
+    };
+    private string[] _labels = { "A", "B", "C", "D", "E" };
+    private RadarChartOptions _options = new() { GridLevels = 1, ShowAxisValues = true };
+    private RadarChartOptions _optionsGrid6 = new() { GridLevels = 6, ShowAxisValues = true };
+}

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) MudBlazor 2021
+// MudBlazor licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using AwesomeAssertions;
+using Bunit;
+using MudBlazor.Charts;
+using NUnit.Framework;
+
+namespace MudBlazor.UnitTests.Charts;
+
+[TestFixture]
+public class RadarChartScalingTests : BunitTest
+{
+    [Test]
+    public void RadarChart_Scaling_SmallValues_GridLevels1()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(1);
+        axisValues[0].TextContent.Should().Be("5");
+    }
+
+    [Test]
+    public void RadarChart_Scaling_SmallValues_GridLevels6()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 6, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(6);
+        // max value is 5. 5/6 = 0.833. FindNextNiceStep(0.833) -> exponent -1, fraction 8.33 -> niceFraction 10 -> step 1.
+        // 1 * 6 = 6. axisMaxValue = 6.
+        // steps: 1, 2, 3, 4, 5, 6
+        axisValues[5].TextContent.Should().Be("6");
+    }
+
+    [Test]
+    public void RadarChart_Scaling_SmallValues_GridLevels2()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 2, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(2);
+        // max 5. 5/2 = 2.5. FindNextNiceStep(2.5) -> 2.5.
+        // 2.5 * 2 = 5.
+        axisValues[0].TextContent.Should().Be("2.5");
+        axisValues[1].TextContent.Should().Be("5");
+    }
+
+    [Test]
+    public void RadarChart_Option_YAxisSuggestedMax()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, YAxisSuggestedMax = 10 };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Last().TextContent.Should().Be("10");
+    }
+
+    [Test]
+    public void RadarChart_Option_YAxisFormat()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, YAxisFormat = "N2" };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues[0].TextContent.Should().Be("5.00");
+    }
+
+    [Test]
+    public void RadarChart_Option_YAxisToStringFunc()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions
+        {
+            GridLevels = 1,
+            ShowAxisValues = true,
+            YAxisToStringFunc = (val) => $"Value: {val}"
+        };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues[0].TextContent.Should().Be("Value: 5");
+    }
+}

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
@@ -95,8 +95,9 @@ public class RadarChartScalingTests : BunitTest
             .Add(p => p.ChartOptions, options)
         );
 
+        var expectedLabel = seriesData[0].ToString(options.YAxisFormat, CultureInfo.CurrentCulture);
         var axisValues = comp.FindAll("text.mud-chart-axis-value");
-        axisValues[0].TextContent.Should().Be("5.00");
+        axisValues[0].TextContent.Should().Be(expectedLabel);
     }
 
     [Test]
@@ -193,5 +194,24 @@ public class RadarChartScalingTests : BunitTest
         {
             label.TextContent.Should().Be("0");
         }
+    }
+
+    [Test]
+    public void RadarChart_Scaling_IntegerData()
+    {
+        var seriesData = new long[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 2, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<long>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<long>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(2);
+        // max 5. 5/2 = 2.5. If it used integer division, it would be 5/2 = 2, step = 2.
+        // With double division, step is 2.5.
+        axisValues[0].TextContent.Should().Be("2.5");
+        axisValues[1].TextContent.Should().Be("5");
     }
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
@@ -73,7 +73,7 @@ public class RadarChartScalingTests : BunitTest
     public void RadarChart_Option_YAxisSuggestedMax()
     {
         var seriesData = new double[] { 5, 5, 5 };
-        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, YAxisSuggestedMax = 10 };
+        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, AxisSuggestedMax = 10 };
 
         var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
@@ -88,14 +88,14 @@ public class RadarChartScalingTests : BunitTest
     public void RadarChart_Option_YAxisFormat()
     {
         var seriesData = new double[] { 5, 5, 5 };
-        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, YAxisFormat = "N2" };
+        var options = new RadarChartOptions { GridLevels = 1, ShowAxisValues = true, AxisFormat = "N2" };
 
         var comp = Context.Render<Radar<double>>(parameters => parameters
             .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
             .Add(p => p.ChartOptions, options)
         );
 
-        var expectedLabel = seriesData[0].ToString(options.YAxisFormat, CultureInfo.CurrentCulture);
+        var expectedLabel = seriesData[0].ToString(options.AxisFormat, CultureInfo.CurrentCulture);
         var axisValues = comp.FindAll("text.mud-chart-axis-value");
         axisValues[0].TextContent.Should().Be(expectedLabel);
     }
@@ -108,7 +108,7 @@ public class RadarChartScalingTests : BunitTest
         {
             GridLevels = 1,
             ShowAxisValues = true,
-            YAxisToStringFunc = (val) => $"Value: {val}"
+            AxisToStringFunc = (val) => $"Value: {val}"
         };
 
         var comp = Context.Render<Radar<double>>(parameters => parameters

--- a/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/RadarChartScalingTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using AwesomeAssertions;
 using Bunit;
@@ -116,5 +117,81 @@ public class RadarChartScalingTests : BunitTest
 
         var axisValues = comp.FindAll("text.mud-chart-axis-value");
         axisValues[0].TextContent.Should().Be("Value: 5");
+    }
+
+    [Test]
+    public void RadarChart_Scaling_GridLevelsZero()
+    {
+        var seriesData = new double[] { 5, 5, 5 };
+        var options = new RadarChartOptions { GridLevels = 0, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        // When GridLevels is 0, GenerateAxisValues returns early.
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(0);
+    }
+
+    [Test]
+    public void RadarChart_Scaling_AllZeroValues()
+    {
+        var seriesData = new double[] { 0, 0, 0 };
+        var options = new RadarChartOptions { GridLevels = 5, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        // CalculateAxisMaxValue returns T.Zero for all zeros.
+        // GenerateAxisValues then uses stepValue = 0.
+        // All labels should be "0".
+        foreach (var label in axisValues)
+        {
+            label.TextContent.Should().Be("0");
+        }
+    }
+
+    [Test]
+    public void RadarChart_Scaling_VeryLargeValues()
+    {
+        var seriesData = new double[] { 1e15, 1e15, 1e15 };
+        var options = new RadarChartOptions { GridLevels = 2, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        axisValues.Count.Should().Be(2);
+        // 1e15 / 2 = 0.5e15 -> 5e14. FindNextNiceStep(5e14) -> 5e14.
+        // 5e14 * 2 = 1e15.
+        axisValues[0].TextContent.Should().Be((5e14).ToString(CultureInfo.InvariantCulture));
+        axisValues[1].TextContent.Should().Be((1e15).ToString(CultureInfo.InvariantCulture));
+    }
+
+    [Test]
+    public void RadarChart_Scaling_NegativeValues()
+    {
+        var seriesData = new double[] { -5, -10, -5 };
+        var options = new RadarChartOptions { GridLevels = 2, ShowAxisValues = true };
+
+        var comp = Context.Render<Radar<double>>(parameters => parameters
+            .Add(p => p.ChartSeries, new List<ChartSeries<double>> { new() { Name = "Series", Data = seriesData } })
+            .Add(p => p.ChartOptions, options)
+        );
+
+        // Max of (-5, -10, -5) is -5.
+        // CalculateAxisMaxValue treats <= 0 as T.Zero.
+        var axisValues = comp.FindAll("text.mud-chart-axis-value");
+        foreach (var label in axisValues)
+        {
+            label.TextContent.Should().Be("0");
+        }
     }
 }

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -168,7 +168,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         }
 
         var gridLevels = T.CreateSaturating(gridLevelsOption);
-        var stepValue = T.Max(T.CreateSaturating(1), axisMaxValue / gridLevels);
+        var stepValue = axisMaxValue / gridLevels;
 
         for (var i = T.One; i <= gridLevels; i++)
         {
@@ -181,9 +181,18 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
             {
                 LabelX = x + 5,
                 LabelY = y - 1,
-                LabelYValue = value.ToString(null, CultureInfo.InvariantCulture),
+                LabelYValue = BuildAxisValueString(value),
             });
         }
+    }
+
+    private string BuildAxisValueString(T value)
+    {
+        var doubleValue = double.CreateSaturating(value);
+
+        return ChartOptions?.YAxisToStringFunc is null
+            ? doubleValue.ToString(ChartOptions?.YAxisFormat, CultureInfo.InvariantCulture)
+            : ChartOptions.YAxisToStringFunc(doubleValue);
     }
 
     private void GenerateAxisLines(int numAxes, double angleStep, double currentAngle, double radius, string[] labelData)
@@ -231,16 +240,56 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     private T CalculateAxisMaxValue(T actualMaxValue)
     {
         Debug.Assert(ChartOptions is not null);
+
+        var maxValue = ChartOptions.YAxisSuggestedMax is null
+            ? actualMaxValue
+            : T.Max(T.CreateSaturating(ChartOptions.YAxisSuggestedMax.Value), actualMaxValue);
+
+        if (maxValue == T.Zero)
+        {
+            return T.Zero;
+        }
+
         var gridLevels = ChartOptions.GridLevels;
-        var minStep = actualMaxValue / T.CreateSaturating(gridLevels);
+        var minStep = double.CreateSaturating(maxValue) / gridLevels;
         var step = FindNextNiceStep(minStep);
 
         return T.CreateSaturating(step * gridLevels);
     }
 
-    private static double FindNextNiceStep(T minStep)
+    private static double FindNextNiceStep(double minStep)
     {
-        return Math.Ceiling(double.CreateSaturating(minStep) / 5) * 5;
+        if (minStep == 0)
+        {
+            return 0;
+        }
+
+        var exponent = Math.Floor(Math.Log10(minStep));
+        var fraction = minStep / Math.Pow(10, exponent);
+        double niceFraction;
+
+        if (fraction <= 1)
+        {
+            niceFraction = 1;
+        }
+        else if (fraction <= 2)
+        {
+            niceFraction = 2;
+        }
+        else if (fraction <= 2.5)
+        {
+            niceFraction = 2.5;
+        }
+        else if (fraction <= 5)
+        {
+            niceFraction = 5;
+        }
+        else
+        {
+            niceFraction = 10;
+        }
+
+        return niceFraction * Math.Pow(10, exponent);
     }
 
     private static (List<ChartSeries<T>> Series, string[] Labels) GroupDataSet(string[] labels, List<ChartSeries<T>> dataSet, bool groupByDataSet = false)

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -93,7 +93,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     }
 
     private void GenerateSvgPaths(List<ChartSeries<T>> seriesData, double[] normalizedData, int numAxes,
-                                  double angleStep, double currentAngle, double radius, T axisMaxValue)
+                                  double angleStep, double currentAngle, double radius, double axisMaxValue)
     {
         Debug.Assert(ChartOptions is not null);
         for (var seriesIndex = 0; seriesIndex < seriesData.Count; seriesIndex++)
@@ -123,7 +123,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     }
 
     private static (string Path, List<SvgPathPoint> Points) GeneratePolygonPath(ChartSeries<T> series, int seriesIndex, int numAxes,
-                                              double angleStep, double currentAngle, double radius, T axisMaxValue)
+                                              double angleStep, double currentAngle, double radius, double axisMaxValue)
     {
         var path = new StringBuilder("M ");
         var points = new List<SvgPathPoint>();
@@ -131,7 +131,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         for (var i = 0; i < Math.Min(series.Data.Values.Count, numAxes); i++)
         {
             var value = series.Data[i].Y;
-            var scale = radius * (axisMaxValue == T.Zero ? 0 : double.CreateSaturating(value / axisMaxValue));
+            var scale = radius * (axisMaxValue == 0 ? 0 : double.CreateSaturating(value) / axisMaxValue);
             scale = Math.Max(0, scale);
 
             var angle = currentAngle + (i * angleStep);
@@ -156,7 +156,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         return (path.ToString(), points);
     }
 
-    private void GenerateAxisValues(double currentAngle, T axisMaxValue, double radius)
+    private void GenerateAxisValues(double currentAngle, double axisMaxValue, double radius)
     {
         Debug.Assert(ChartOptions is not null);
         var axisAngle = currentAngle;
@@ -167,13 +167,13 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
             return;
         }
 
-        var gridLevels = T.CreateSaturating(gridLevelsOption);
+        var gridLevels = (double)gridLevelsOption;
         var stepValue = axisMaxValue / gridLevels;
 
-        for (var i = T.One; i <= gridLevels; i++)
+        for (var i = 1; i <= gridLevelsOption; i++)
         {
             var value = i * stepValue;
-            var valueRadius = radius * double.CreateSaturating(i / gridLevels);
+            var valueRadius = radius * (i / gridLevels);
             var x = Math.Cos(axisAngle) * valueRadius;
             var y = Math.Sin(axisAngle) * valueRadius;
 
@@ -186,13 +186,11 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         }
     }
 
-    private string BuildAxisValueString(T value)
+    private string BuildAxisValueString(double value)
     {
-        var doubleValue = double.CreateSaturating(value);
-
         return ChartOptions?.YAxisToStringFunc is null
-            ? ToS(doubleValue, ChartOptions?.YAxisFormat)
-            : ChartOptions.YAxisToStringFunc(doubleValue);
+            ? ToS(value, ChartOptions?.YAxisFormat)
+            : ChartOptions.YAxisToStringFunc(value);
     }
 
     private void GenerateAxisLines(int numAxes, double angleStep, double currentAngle, double radius, string[] labelData)
@@ -237,24 +235,24 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         }
     }
 
-    private T CalculateAxisMaxValue(T actualMaxValue)
+    private double CalculateAxisMaxValue(T actualMaxValue)
     {
         Debug.Assert(ChartOptions is not null);
 
         var maxValue = ChartOptions.YAxisSuggestedMax is null
-            ? actualMaxValue
-            : T.Max(T.CreateSaturating(ChartOptions.YAxisSuggestedMax.Value), actualMaxValue);
+            ? double.CreateSaturating(actualMaxValue)
+            : Math.Max(ChartOptions.YAxisSuggestedMax.Value, double.CreateSaturating(actualMaxValue));
 
-        if (maxValue <= T.Zero)
+        if (maxValue <= 0)
         {
-            return T.Zero;
+            return 0;
         }
 
         var gridLevels = Math.Max(1, ChartOptions.GridLevels);
-        var minStep = double.CreateSaturating(maxValue) / gridLevels;
+        var minStep = maxValue / gridLevels;
         var step = FindNextNiceStep(minStep);
 
-        return T.CreateSaturating(step * gridLevels);
+        return step * gridLevels;
     }
 
     private static double FindNextNiceStep(double minStep)

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -188,9 +188,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
 
     private string BuildAxisValueString(double value)
     {
-        return ChartOptions?.YAxisToStringFunc is null
-            ? ToS(value, ChartOptions?.YAxisFormat)
-            : ChartOptions.YAxisToStringFunc(value);
+        return ChartOptions?.AxisToStringFunc is null
+            ? ToS(value, ChartOptions?.AxisFormat)
+            : ChartOptions.AxisToStringFunc(value);
     }
 
     private void GenerateAxisLines(int numAxes, double angleStep, double currentAngle, double radius, string[] labelData)
@@ -239,9 +239,9 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
     {
         Debug.Assert(ChartOptions is not null);
 
-        var maxValue = ChartOptions.YAxisSuggestedMax is null
+        var maxValue = ChartOptions.AxisSuggestedMax is null
             ? double.CreateSaturating(actualMaxValue)
-            : Math.Max(ChartOptions.YAxisSuggestedMax.Value, double.CreateSaturating(actualMaxValue));
+            : Math.Max(ChartOptions.AxisSuggestedMax.Value, double.CreateSaturating(actualMaxValue));
 
         if (maxValue <= 0)
         {

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor.cs
@@ -191,7 +191,7 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
         var doubleValue = double.CreateSaturating(value);
 
         return ChartOptions?.YAxisToStringFunc is null
-            ? doubleValue.ToString(ChartOptions?.YAxisFormat, CultureInfo.InvariantCulture)
+            ? ToS(doubleValue, ChartOptions?.YAxisFormat)
             : ChartOptions.YAxisToStringFunc(doubleValue);
     }
 
@@ -245,12 +245,12 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
             ? actualMaxValue
             : T.Max(T.CreateSaturating(ChartOptions.YAxisSuggestedMax.Value), actualMaxValue);
 
-        if (maxValue == T.Zero)
+        if (maxValue <= T.Zero)
         {
             return T.Zero;
         }
 
-        var gridLevels = ChartOptions.GridLevels;
+        var gridLevels = Math.Max(1, ChartOptions.GridLevels);
         var minStep = double.CreateSaturating(maxValue) / gridLevels;
         var step = FindNextNiceStep(minStep);
 
@@ -259,35 +259,21 @@ public partial class Radar<T> : MudRadialChartBase<T, RadarChartOptions> where T
 
     private static double FindNextNiceStep(double minStep)
     {
-        if (minStep == 0)
+        if (minStep <= 0 || !double.IsFinite(minStep))
         {
             return 0;
         }
 
         var exponent = Math.Floor(Math.Log10(minStep));
         var fraction = minStep / Math.Pow(10, exponent);
-        double niceFraction;
-
-        if (fraction <= 1)
+        var niceFraction = fraction switch
         {
-            niceFraction = 1;
-        }
-        else if (fraction <= 2)
-        {
-            niceFraction = 2;
-        }
-        else if (fraction <= 2.5)
-        {
-            niceFraction = 2.5;
-        }
-        else if (fraction <= 5)
-        {
-            niceFraction = 5;
-        }
-        else
-        {
-            niceFraction = 10;
-        }
+            <= 1.0 => 1.0,
+            <= 2.0 => 2.0,
+            <= 2.5 => 2.5,
+            <= 5.0 => 5.0,
+            _ => 10.0
+        };
 
         return niceFraction * Math.Pow(10, exponent);
     }

--- a/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
@@ -90,6 +90,23 @@ public class RadarChartOptions : DefaultRadialChartOptions, IRadialChartOptions,
     /// </summary>
     public double DataPointRadius { get; set; } = 3.0;
 
+    /// <summary>
+    /// The suggested maximum value for the Y-axis.
+    /// </summary>
+    public double? YAxisSuggestedMax { get; set; }
+
+    /// <summary>
+    /// The format applied to numbers on the vertical axis.
+    /// </summary>
+    public string? YAxisFormat { get; set; }
+
+    /// <summary>
+    /// Custom formatting function for vertical axis values.
+    /// If set, this function will be used to convert Y-axis values to strings for display purposes.
+    /// If not provided, <see cref="YAxisFormat"/> will be used instead.
+    /// </summary>
+    public Func<double, string>? YAxisToStringFunc { get; set; }
+
     /// <inheritdoc/>
     public override AggregationOption AggregationOption { get; set; } = AggregationOption.GroupByDataSet;
 

--- a/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
@@ -91,21 +91,21 @@ public class RadarChartOptions : DefaultRadialChartOptions, IRadialChartOptions,
     public double DataPointRadius { get; set; } = 3.0;
 
     /// <summary>
-    /// The suggested maximum value for the Y-axis.
+    /// The suggested maximum value for the axis.
     /// </summary>
-    public double? YAxisSuggestedMax { get; set; }
+    public double? AxisSuggestedMax { get; set; }
 
     /// <summary>
-    /// The format applied to numbers on the vertical axis.
+    /// The format applied to numbers on the axis.
     /// </summary>
-    public string? YAxisFormat { get; set; }
+    public string? AxisFormat { get; set; }
 
     /// <summary>
     /// Custom formatting function for vertical axis values.
     /// If set, this function will be used to convert Y-axis values to strings for display purposes.
-    /// If not provided, <see cref="YAxisFormat"/> will be used instead.
+    /// If not provided, <see cref="AxisFormat"/> will be used instead.
     /// </summary>
-    public Func<double, string>? YAxisToStringFunc { get; set; }
+    public Func<double, string>? AxisToStringFunc { get; set; }
 
     /// <inheritdoc/>
     public override AggregationOption AggregationOption { get; set; } = AggregationOption.GroupByDataSet;


### PR DESCRIPTION
This PR resolves a significant discrepancy between actual data values and rendered axis labels in the `MudChart` (Radar type) when `GridLevels` is set to a value greater than 1.

Previously, the scaling logic forced intervals to be multiples of 5, which caused labels to jump to much higher values than the data suggested (e.g., labels showing 30 for data maxed at 5).

Key changes:
1. **Improved Scaling Algorithm**: Replaced the simplistic `FindNextNiceStep` with a robust algorithm that uses powers of 10 and clean fractions (1, 2, 2.5, 5) to determine intuitive axis intervals.
2. **Axis Customization**: Added the following properties to `RadarChartOptions`:
   - `YAxisSuggestedMax`: Allows users to specify a minimum maximum value for the axis.
   - `YAxisFormat`: Enables standard .NET numeric formatting for axis labels.
   - `YAxisToStringFunc`: Provides a callback for complete custom label formatting.
3. **Tests**: Added comprehensive unit tests in `RadarChartScalingTests.cs` covering various data scales and the new customization options.

This ensures that Radar charts represent the actual distribution of data much more accurately while offering the same level of axis control found in other MudBlazor charts.

---
*PR created automatically by Jules for task [16378307660344899515](https://jules.google.com/task/16378307660344899515) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Y-axis customization for radar charts: YAxisSuggestedMax, YAxisFormat, and YAxisToStringFunc.
  * Improved axis scaling for radar charts with better handling of grid levels, small/large/zero/negative values, and formatted labels.

* **Tests**
  * Added comprehensive unit tests covering axis scaling, formatting, suggested max, and edge cases.

* **Documentation**
  * Updated radar chart docs to describe the new Y-axis options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->