### PR TITLE
Fix ScatterPlot overlay support

### DIFF
--- a/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/CombinedChartTest.razor
+++ b/src/MudBlazor.UnitTests.Viewer/TestComponents/Charts/CombinedChartTest.razor
@@ -1,7 +1,7 @@
 ﻿@using MudBlazor.Charts
 
 <MudChart T="double" ChartType="ChartType.StackedBar" ChartSeries="@StackedDataSet" ChartOptions="@_barChartOptions" MatchBoundsToSize="true" Width="100%" Height="500px">
-    <Line ChartSeries="@LineDataSet" ChartOptions="@_lineChartOptions" />
+    <ScatterPlot ChartSeries="@LineDataSet" ChartOptions="@_scatterChartOptions" />
 </MudChart>
 
 @code {
@@ -26,10 +26,9 @@
         new() { Name = "Overall Change", Data = new([650, 550, 450, 380, 300, 320, 350, 400, 380, 420, 350, 650, 880, -300, 400, 250, 300, 320, 280, 350, 300, 400, 380, 420, 750, 600, 200, 300, 400, 380, 350, 400, 200]) }
     ];
 
-    private LineChartOptions _lineChartOptions = new LineChartOptions()
+    private ScatterPlotChartOptions _scatterChartOptions = new ScatterPlotChartOptions()
     {
         ChartPalette = ["#000000"],
-        ShowDataMarkers = true,
         LineStrokeWidth = 1.8,
     };
 }

--- a/src/MudBlazor.UnitTests/Components/Charts/ScatterPlotOverlayTests.cs
+++ b/src/MudBlazor.UnitTests/Components/Charts/ScatterPlotOverlayTests.cs
@@ -1,0 +1,71 @@
+using Bunit;
+using MudBlazor.Charts;
+using NUnit.Framework;
+using AwesomeAssertions;
+
+namespace MudBlazor.UnitTests.Charts
+{
+    [TestFixture]
+    public class ScatterPlotOverlayTests : BunitTest
+    {
+        [Test]
+        public async Task ScatterPlotAsOverlay_RendersPoints()
+        {
+            var barSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Bar Series", Data = new double[] { 10, 20, 30 } }
+            };
+
+            var scatterSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Scatter Overlay", Data = new double[] { 15, 25, 35 } }
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, barSeries)
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<ScatterPlot<double>>(0);
+                    builder.AddAttribute(1, nameof(ScatterPlot<double>.ChartSeries), scatterSeries);
+                    builder.CloseComponent();
+                }));
+
+            // Trigger a re-render to ensure child components are initialized and registered
+            comp.Render();
+
+            var circles = comp.FindAll("circle.mud-chart-point");
+            circles.Count.Should().Be(6);
+        }
+
+        [Test]
+        public async Task ScatterPlotAsOverlay_UsesIndicesForX_WhenXIsNull()
+        {
+            var barSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Bar Series", Data = new double[] { 100 } }
+            };
+
+            var scatterSeries = new List<ChartSeries<double>>
+            {
+                new() { Name = "Scatter Overlay", Data = new double[] { 50 } } // X is null
+            };
+
+            var comp = Context.Render<MudChart<double>>(parameters => parameters
+                .Add(p => p.ChartType, ChartType.Bar)
+                .Add(p => p.ChartSeries, barSeries)
+                .Add(p => p.ChildContent, builder =>
+                {
+                    builder.OpenComponent<ScatterPlot<double>>(0);
+                    builder.AddAttribute(1, nameof(ScatterPlot<double>.ChartSeries), scatterSeries);
+                    builder.CloseComponent();
+                }));
+
+            // Trigger a re-render to ensure child components are initialized and registered
+            comp.Render();
+
+            // If it didn't throw and rendered circles, it's using indices.
+            comp.FindAll("circle.mud-chart-point").Count.Should().Be(2);
+        }
+    }
+}

--- a/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
+++ b/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
@@ -4,36 +4,40 @@
 
 @typeparam T
 
-<div @attributes="UserAttributes" class="@Classname">
-    <BaseAxisChart T="T"
-                   TChartOptions="ScatterPlotChartOptions"
-                   AxisChanged="AxisChanged"
-                   ElementRefChanged="SetElementReference"
-                   Width="@Width"
-                   Height="@Height"
-                   ViewBoxWidth="_boundWidth"
-                   ViewBoxHeight="_boundHeight"
-                   MatchBoundsToSize="@MatchBoundsToSize"
-                   ChartClass="mud-chart-scatter"
-                   ChartSeries="@ChartSeries"
-                   ChartLabels="@ChartLabels"
-                   ChartOptions="@ChartOptions"
-                   XAxisTitle="@ChartOptions?.XAxisTitle"
-                   YAxisTitle="@ChartOptions?.YAxisTitle"
-                   ChartType="@ChartType"
-                   SeriesContent="@RenderScatterPoints()"
-                   TooltipContent="@RenderTooltip()"
-                   CustomGraphics="@CustomGraphics"
-                   HoveredSegment="@HoveredDataPointPath"
-                   HorizontalLines="@HorizontalLines"
-                   VerticalLines="@VerticalLines"
-                   HorizontalValues="@HorizontalValues"
-                   VerticalValues="@VerticalValues"
-                   UserAttributes="@UserAttributes" />
+@if (!IsOverlayChart)
+{
+    <div @attributes="UserAttributes" class="@Classname">
+        <BaseAxisChart T="T"
+                       TChartOptions="ScatterPlotChartOptions"
+                       AxisChanged="AxisChanged"
+                       ElementRefChanged="SetElementReference"
+                       Width="@Width"
+                       Height="@Height"
+                       ViewBoxWidth="_boundWidth"
+                       ViewBoxHeight="_boundHeight"
+                       MatchBoundsToSize="@MatchBoundsToSize"
+                       ChartClass="mud-chart-scatter"
+                       ChartSeries="@ChartSeries"
+                       ChartLabels="@ChartLabels"
+                       ChartOptions="@ChartOptions"
+                       XAxisTitle="@ChartOptions?.XAxisTitle"
+                       YAxisTitle="@ChartOptions?.YAxisTitle"
+                       ChartType="@ChartType"
+                       SeriesContent="@RenderScatterPoints()"
+                       TooltipContent="@RenderTooltip()"
+                       ChildContent="@OverlayContent"
+                       CustomGraphics="@CustomGraphics"
+                       HoveredSegment="@HoveredDataPointPath"
+                       HorizontalLines="@HorizontalLines"
+                       VerticalLines="@VerticalLines"
+                       HorizontalValues="@HorizontalValues"
+                       VerticalValues="@VerticalValues"
+                       UserAttributes="@UserAttributes" />
 
-    <Legend T="T" Data="@Legends" ShowLegend="@ChartOptions?.ShowLegend" CanHideSeries="@CanHideSeries"
-            ChartPalette="@LegendPalette" OnLegendSelected="async (i) => await SetSelectedIndexAsync(i)" />
-</div>
+        <Legend T="T" Data="@Legends" ShowLegend="@ChartOptions?.ShowLegend" CanHideSeries="@CanHideSeries"
+                ChartPalette="@LegendPalette" OnLegendSelected="async (i) => await SetSelectedIndexAsync(i)" />
+    </div>
+}
 
 @code {
   private const double DataPointStroke = 1.5d;
@@ -202,4 +206,9 @@
             }
         }
     };
+
+    private RenderFragment Chart => @<g class="mud-charts-scatter-series">
+        @RenderScatterPoints()
+        @RenderTooltip()
+    </g>;
 }

--- a/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor.cs
@@ -36,26 +36,71 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
         ChartType = ChartType.ScatterPlot;
         ChartOptions ??= new ScatterPlotChartOptions();
 
+        if (ChartReference is IMudAxisChart<T> axisChart)
+        {
+            axisChart.OverlayChart = this;
+            axisChart.OverlayContent = this.Chart;
+        }
+
         base.OnInitialized();
     }
 
     public override void RebuildChart()
     {
-        Series = (ChartContainer != null && ChartReference is MudChart<T>)
+        if (IsOverlayChart && SharedData is null)
+        {
+            return;
+        }
+
+        Series = (ChartContainer != null && ChartReference is MudChart<T> && !IsOverlayChart)
             ? ChartContainer.ChartSeries
             : ChartSeries;
 
-        SetBounds();
-        ComputeXAxisScale(out _gridXUnits, out _lowestVerticalLine, out var numVerticalLines);
-        ComputeYAxisScale(out var gridYUnits, out var lowestHorizontalLine, out var numHorizontalLines);
+        T gridYUnits;
+        int lowestHorizontalLine;
+        int numHorizontalLines;
+        double horizontalSpace;
+        double verticalSpace;
+        int numVerticalLines;
 
-        var verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, numHorizontalLines - 1);
-        _horizontalSpacePerXUnit = (_boundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, numVerticalLines - 1);
+        if (!IsOverlayChart)
+        {
+            SetBounds();
+            ComputeXAxisScale(out _gridXUnits, out _lowestVerticalLine, out numVerticalLines);
+            ComputeYAxisScale(out gridYUnits, out lowestHorizontalLine, out numHorizontalLines);
 
-        GenerateHorizontalGridLines(numHorizontalLines, lowestHorizontalLine, gridYUnits, verticalSpace);
-        GenerateVerticalGridLines(numVerticalLines, 0, _horizontalSpacePerXUnit);
-        GenerateChartLines(lowestHorizontalLine, gridYUnits, _horizontalSpacePerXUnit, verticalSpace);
+            verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, numHorizontalLines - 1);
+            horizontalSpace = _horizontalSpacePerXUnit = (_boundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, numVerticalLines - 1);
+
+            GenerateHorizontalGridLines(numHorizontalLines, lowestHorizontalLine, gridYUnits, verticalSpace);
+            GenerateVerticalGridLines(numVerticalLines, 0, _horizontalSpacePerXUnit);
+
+            // If this is not an overlay chart, we generate the shared plot points if an overlay exists
+            SharedData = OverlayChart is IMudAxisChart<T> ? new AxisGridData<T>(lowestHorizontalLine, numHorizontalLines, gridYUnits, _boundWidth, _boundHeight) : null;
+        }
+        else
+        {
+            // If this is an overlay chart, we use the shared plot points from the main chart
+            var area = SharedData!.Value;
+
+            lowestHorizontalLine = area.LowestHorizontalLine;
+            gridYUnits = area.YAxisTicks;
+            numHorizontalLines = area.HorizontalLineCount;
+
+            _boundWidth = area.BoundWidth;
+            _boundHeight = area.BoundHeight;
+
+            verticalSpace = (_boundHeight - VerticalStartSpace - VerticalEndSpace) / Math.Max(1, numHorizontalLines - 1);
+
+            // For overlays on categorical charts (Bar, StackedBar, etc.), we align X with the categories/indices.
+            // We assume the horizontal space is divided by the number of categories.
+            numVerticalLines = Series.Any() ? Series.Max(s => s.Data.Count) : 1;
+            horizontalSpace = _horizontalSpacePerXUnit = (_boundWidth - HorizontalStartSpace - HorizontalEndSpace) / Math.Max(1, numVerticalLines - 1);
+        }
+
+        GenerateChartLines(lowestHorizontalLine, gridYUnits, horizontalSpace, verticalSpace);
         GenerateLegends();
+        RenderOverlay();
     }
 
     private void ComputeYAxisScale(out T gridYUnits, out int lowestHorizontalLine, out int numHorizontalLines)
@@ -151,12 +196,12 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
 
     protected override TReturn GetDataValue<TReturn>(int seriesIndex, int dataPointIndex)
     {
-        return (TReturn)Convert.ChangeType(Series[seriesIndex].Data.Points[dataPointIndex].Y, typeof(TReturn));
+        return (TReturn)Convert.ChangeType(Series[seriesIndex].Data[dataPointIndex].Y, typeof(TReturn));
     }
 
     protected override string GetLabelXValue(int seriesIndex, int dataPointIndex)
     {
-        var x = Series[seriesIndex].Data.Points[dataPointIndex].X;
+        var x = Series[seriesIndex].Data[dataPointIndex].X;
         if (x is T xVal)
         {
             return ChartOptions?.XAxisFormat is { } fmt
@@ -169,7 +214,7 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
 
     protected override (double x, double y) GetXYForDataPoint(int seriesIndex, int dataPointIndex, int lowestHorizontalLine, T gridYUnits, double horizontalSpace, double verticalSpace)
     {
-        var point = Series[seriesIndex].Data.Points[dataPointIndex];
+        var point = Series[seriesIndex].Data[dataPointIndex];
 
         // Map Y to screen coordinate
         var gridValueY = ((double.CreateSaturating(point.Y) / double.CreateSaturating(gridYUnits)) - lowestHorizontalLine) * verticalSpace;
@@ -181,6 +226,11 @@ partial class ScatterPlot<T> : MudAxisLineChartBase<T, ScatterPlotChartOptions> 
         {
             var gridValueX = ((double.CreateSaturating(xVal) / double.CreateSaturating(_gridXUnits)) - _lowestVerticalLine) * _horizontalSpacePerXUnit;
             screenX = HorizontalStartSpace + gridValueX;
+        }
+        else if (IsOverlayChart || point.X is null)
+        {
+            // Fallback to index-based X for overlays or if X is missing
+            screenX = HorizontalStartSpace + (dataPointIndex * horizontalSpace);
         }
         else
         {


### PR DESCRIPTION
This change enables the ScatterPlot component to be used as an overlay in MudChart. It now correctly registers itself with the parent axis-based chart, utilizes shared axis data for alignment, and falls back to data point indices for X-coordinates when used as an overlay (aligning it with categorical charts like Bar or StackedBar). Tooltips and legend support are also included for the overlay series.

---
*PR created automatically by Jules for task [16236921566741372236](https://jules.google.com/task/16236921566741372236) started by @Anu6is*