### PR TITLE
Fix MudSelect visible caret in Firefox

### DIFF
--- a/src/MudBlazor.UnitTests/Components/SelectTests.cs
+++ b/src/MudBlazor.UnitTests/Components/SelectTests.cs
@@ -424,7 +424,7 @@ namespace MudBlazor.UnitTests.Components
             await comp.WaitForAssertionAsync(() => select.Instance.ReadValue.Should().Be(2));
             select.Instance.ReadText.Should().Be("2");
             comp.FindComponent<MudInput<string>>().Instance.ReadValue.Should().Be("2");
-            comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Text); // because list item has no render fragment, so we show it as text
+            comp.FindComponent<MudInput<string>>().Instance.InputType.Should().Be(InputType.Hidden); // MudSelect now always uses Hidden InputType
         }
 
         /// <summary>
@@ -542,14 +542,14 @@ namespace MudBlazor.UnitTests.Components
 
             select.Instance.ReadValue.Should().Be(1);
             select.Instance.ReadText.Should().Be("1");
-            comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none");
+            comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:inline");
 
             await input.MouseDownAsync();
             await comp.WaitForAssertionAsync(() => comp.FindAll("div.mud-list-item").Count.Should().BeGreaterThan(0));
             var items = comp.FindAll("div.mud-list-item").ToArray();
             await items[1].ClickAsync();
             await comp.WaitForAssertionAsync(() => comp.Find("div.mud-popover").ClassList.Should().NotContain("mud-popover-open"));
-            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:none"));
+            await comp.WaitForAssertionAsync(() => comp.Find("div.mud-input-slot").Attributes["style"].Value.Should().Contain("display:inline"));
             select.Instance.ReadValue.Should().Be(2);
             select.Instance.ReadText.Should().Be("2");
         }
@@ -2016,7 +2016,9 @@ namespace MudBlazor.UnitTests.Components
 
             displaySlots = comp.FindAll("div.mud-input-slot");
             displaySlot = displaySlots.FirstOrDefault(x => x.GetAttribute("style")?.Contains("display:inline") == true || x.GetAttribute("style")?.Contains("display: inline") == true);
-            displaySlot.Should().BeNull("because ToStringFunc should take precedence over RenderFragment when it returns a non-null value");
+            displaySlot.Should().NotBeNull("because we are now always using a div for display");
+            displaySlot.InnerHtml.Should().NotContain("custom-render", "because ToStringFunc should take precedence over RenderFragment when it returns a non-null value");
+            displaySlot.TextContent.Trim().Should().Be("ITEM2");
 
             var input = comp.Find("input");
             input.GetAttribute("value").Should().Be("ITEM2");

--- a/src/MudBlazor/Base/MudBaseInput.cs
+++ b/src/MudBlazor/Base/MudBaseInput.cs
@@ -19,7 +19,7 @@ namespace MudBlazor
         /// This field is set to <c>true</c> to prevent validation from occurring more than once during a validation cycle.  Each change in the <see cref="Value"/> will reset this field to <c>false</c>.
         /// </remarks>
         private bool _validated;
-        protected bool _isFocused;
+        protected internal bool _isFocused;
         protected bool _forceTextUpdate;
 
         /// <summary>

--- a/src/MudBlazor/Components/Select/MudSelect.razor
+++ b/src/MudBlazor/Components/Select/MudSelect.razor
@@ -21,15 +21,18 @@
                          ForId="@InputElementId"
                          @onmousedown="@HandleMouseDown">
             <InputContent>
+                @{
+                    var val = Strict && !IsValueInList ? null : ReadText;
+                }
                 <MudInput @ref="_elementReference"
-                          InputType="@(CanRenderValue || (Strict && !IsValueInList) ? InputType.Hidden : InputType.Text)"
+                          InputType="InputType.Hidden"
                           Class="@InputClassname"
                           Margin="@Margin"
                           Placeholder="@Placeholder"
                           Label="@Label"
                           Variant="@Variant"
                           Typo="@Typo"
-                          Value="@(Strict && !IsValueInList ? null : ReadText)"
+                          Value="@val"
                           Underline="@Underline"
                           Disabled="@GetDisabledState()"
                           ReadOnly="true"
@@ -49,12 +52,20 @@
                           OnClearButtonClick="@(async (e) => await SelectClearButtonClickHandlerAsync(e))"
                           @attributes="UserAttributes"
                           OnBlur="@OnBlurAsync"
-                          ShrinkLabel="@(ShrinkLabel || CanRenderValue)"
+                          ShrinkLabel="@(ShrinkLabel || CanRenderValue || !string.IsNullOrWhiteSpace(val) || _isFocused)"
                           InputId="@InputElementId"
                           Required="@Required">
                     @if (CanRenderValue)
                     {
                         @GetSelectedValuePresenter()
+                    }
+                    else if (!string.IsNullOrWhiteSpace(val))
+                    {
+                        @val
+                    }
+                    else
+                    {
+                        <span class="mud-select-placeholder">@Placeholder</span>
                     }
                 </MudInput>
                 @if (FitContent)

--- a/src/MudBlazor/Styles/components/_select.scss
+++ b/src/MudBlazor/Styles/components/_select.scss
@@ -128,3 +128,8 @@
 .mud-width-content {
     max-width: min-content;
 }
+
+.mud-select-placeholder {
+    color: currentColor;
+    opacity: 0.42;
+}


### PR DESCRIPTION
MudSelect showed a visible caret in Firefox because it was using a readonly text input for string-based values. By switching to a hidden input and rendering the value in a focusable div slot, the caret is removed while maintaining accessibility and functionality.

---
*PR created automatically by Jules for task [5128115825772708141](https://jules.google.com/task/5128115825772708141) started by @Anu6is*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated MudSelect component unit tests to reflect revised rendering behavior for input display areas, label shrinking logic, and placeholder handling.

* **Style**
  * Enhanced MudSelect placeholder styling with refined opacity and color presentation for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->