### PR TITLE
Normalize tooltip sizes across all chart types

### DIFF
--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor
@@ -69,7 +69,14 @@
         else
         {
             var tooltipFormat = BuildTooltipFormat();
-            <ChartTooltip Title="@tooltipFormat.title" Subtitle="@tooltipFormat.subtitle" Color="@color" X="@tooltipX" Y="@tooltipY" />
+            <ChartTooltip Title="@tooltipFormat.title"
+                          Subtitle="@tooltipFormat.subtitle"
+                          Color="@color"
+                          X="@tooltipX"
+                          Y="@tooltipY"
+                          FontSize="@(ChartOptions.TooltipFontSize * TooltipScalingFactor)"
+                          PaddingSize="@(5.0 * TooltipScalingFactor)"
+                          StrokeWidth="@(1.0 * TooltipScalingFactor)" />
         }
     }
 </svg>

--- a/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
+++ b/src/MudBlazor/Components/Chart/Base/BaseRadialChart.razor.cs
@@ -165,6 +165,13 @@ public partial class BaseRadialChart<T, TChartOptions> : MudComponentBase
     public RenderFragment<(SvgPath Segment, string Color)>? TooltipTemplate { get; set; }
 
     /// <summary>
+    /// The scaling factor for tooltips based on the chart's coordinate system.
+    /// </summary>
+    [Parameter]
+    [Category(CategoryTypes.Chart.Appearance)]
+    public double TooltipScalingFactor { get; set; } = 1.0;
+
+    /// <summary>
     /// The function to determine the position of the tooltip.
     /// </summary>
     [Parameter]

--- a/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/DefaultChartOptions.cs
@@ -39,6 +39,14 @@ public abstract class DefaultChartOptions : IChartOptions
     public virtual string? TooltipSubtitleFormat { get; set; }
 
     /// <summary>
+    /// The font size for the tooltip.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>12.0</c>.
+    /// </remarks>
+    public virtual double TooltipFontSize { get; set; } = 12.0;
+
+    /// <summary>
     /// The list of colors applied to series values.
     /// </summary>
     /// <remarks>

--- a/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Base/IChartOptions.cs
@@ -33,4 +33,9 @@ public interface IChartOptions
     /// The format string for tooltip subtitles.
     /// </summary>
     public string? TooltipSubtitleFormat { get; set; }
+
+    /// <summary>
+    /// The font size for the tooltip.
+    /// </summary>
+    public double TooltipFontSize { get; set; }
 }

--- a/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudChartBase.cs
@@ -168,6 +168,11 @@ public abstract class MudChartBase<T, TOptions> : MudComponentBase, IMudChart<T>
     public virtual string[] LegendPalette => ChartOptions?.ChartPalette ?? [];
 
     /// <summary>
+    /// The scaling factor for tooltips based on the chart's coordinate system.
+    /// </summary>
+    protected virtual double TooltipScalingFactor => 1.0;
+
+    /// <summary>
     /// The CSS classes for the chart component.
     /// </summary>
     protected string Classname => new CssBuilder("mud-chart")

--- a/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
+++ b/src/MudBlazor/Components/Chart/Base/MudRadialChartBase.cs
@@ -81,6 +81,28 @@ public abstract class MudRadialChartBase<T, TOptions> : MudChartBase<T, TOptions
     protected virtual double NormalizedRadius => 100;
 
     /// <summary>
+    /// The scaling factor for tooltips based on the chart's coordinate system.
+    /// </summary>
+    protected override double TooltipScalingFactor
+    {
+        get
+        {
+            if (Radius == NormalizedRadius)
+            {
+                var minDimension = Math.Min(_boundWidth, _boundHeight);
+                if (minDimension <= 0)
+                {
+                    return 1.0;
+                }
+
+                return (NormalizedRadius * 2) / minDimension;
+            }
+
+            return 1.0;
+        }
+    }
+
+    /// <summary>
     /// The bounding box of the chart arc.
     /// </summary>
     protected string ViewBox { get; set; } = "-100 -100 200 200";

--- a/src/MudBlazor/Components/Chart/Charts/Bar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Bar.razor
@@ -108,6 +108,9 @@
                 builder.AddAttribute(seq++, "Color", color);
                 builder.AddAttribute(seq++, "X", tooltipX);
                 builder.AddAttribute(seq++, "Y", tooltipY);
+                builder.AddAttribute(seq++, "FontSize", ChartOptions.TooltipFontSize * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "PaddingSize", 5.0 * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "StrokeWidth", 1.0 * TooltipScalingFactor);
                 builder.CloseComponent();
             }
         }

--- a/src/MudBlazor/Components/Chart/Charts/Donut.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Donut.razor
@@ -22,6 +22,7 @@
                      UserAttributes="@UserAttributes"
                      TooltipTemplate="@TooltipTemplate"
                      TooltipPositionFunc="@TooltipPositionFunc"
+                     TooltipScalingFactor="@TooltipScalingFactor"
                      OnPathClick="async (i) => await SetSelectedIndexAsync(i)"
                      OnMouseOver="(x) => OnSegmentMouseOver(x.Args, x.Segment)"
                      OnMouseOut="() => OnSegmentMouseOut()" />

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor
@@ -377,13 +377,26 @@
                     .Replace("{{X_VALUE}}", ChartLabels.Length > _hoveredCell.Column ? ChartLabels[_hoveredCell.Column] : string.Empty)
                     .Replace("{{Y_VALUE}}", _hoveredCell.Value.ToString()) ?? string.Empty;
 
-                <ChartTooltip Title="@tooltipTitle" Subtitle="@tooltipSubtitle" Color="@color" X="@tooltipX" Y="@tooltipY"/>
+                <ChartTooltip Title="@tooltipTitle"
+                              Subtitle="@tooltipSubtitle"
+                              Color="@color"
+                              X="@tooltipX"
+                              Y="@tooltipY"
+                              FontSize="@(ChartOptions!.TooltipFontSize * TooltipScalingFactor)"
+                              PaddingSize="@(5.0 * TooltipScalingFactor)"
+                              StrokeWidth="@(1.0 * TooltipScalingFactor)" />
             }
         }
     }
     @if (_options is { ShowToolTips: true } && _hoveredLegend is not null)
     {
-        <ChartTooltip Title="@_hoveredLegend.Value.value.ToString()" Color="@_hoveredLegend.Value.color" X="@_hoveredLegendPosition.X" Y="@_hoveredLegendPosition.Y"/>
+        <ChartTooltip Title="@_hoveredLegend.Value.value.ToString()"
+                      Color="@_hoveredLegend.Value.color"
+                      X="@_hoveredLegendPosition.X"
+                      Y="@_hoveredLegendPosition.Y"
+                      FontSize="@(ChartOptions!.TooltipFontSize * TooltipScalingFactor)"
+                      PaddingSize="@(5.0 * TooltipScalingFactor)"
+                      StrokeWidth="@(1.0 * TooltipScalingFactor)" />
     }
 </svg>
 

--- a/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/HeatMap.razor.cs
@@ -133,6 +133,7 @@ namespace MudBlazor.Charts
         /// </summary>
         public (int Row, int Column) SelectedCell { get; set; }
 
+
         /// <summary>
         /// The chart, if any, containing this component.
         /// </summary>

--- a/src/MudBlazor/Components/Chart/Charts/Line.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Line.razor
@@ -164,6 +164,9 @@
                 builder.AddAttribute(seq++, "Color", color);
                 builder.AddAttribute(seq++, "X", tooltipX);
                 builder.AddAttribute(seq++, "Y", tooltipY);
+                builder.AddAttribute(seq++, "FontSize", ChartOptions.TooltipFontSize * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "PaddingSize", 5.0 * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "StrokeWidth", 1.0 * TooltipScalingFactor);
                 builder.CloseComponent();
             }
         }

--- a/src/MudBlazor/Components/Chart/Charts/Pie.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Pie.razor
@@ -20,6 +20,7 @@
                      UserAttributes="@UserAttributes"
                      TooltipTemplate="@TooltipTemplate"
                      TooltipPositionFunc="@TooltipPositionFunc"
+                     TooltipScalingFactor="@TooltipScalingFactor"
                      OnPathClick="async (i) => await SetSelectedIndexAsync(i)"
                      OnMouseOver="(x) => OnSegmentMouseOver(x.Args, x.Segment)"
                      OnMouseOut="OnSegmentMouseOut" />

--- a/src/MudBlazor/Components/Chart/Charts/Radar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Radar.razor
@@ -23,6 +23,7 @@
                      UserAttributes="@UserAttributes"
                      TooltipTemplate="@TooltipTemplate"
                      TooltipPositionFunc="@TooltipPositionFunc"
+                     TooltipScalingFactor="@TooltipScalingFactor"
                      OnPathClick="async (i) => await SetSelectedIndexAsync(i)"
                      OnMouseOver="(x) => OnSegmentMouseOver(x.Args, x.Segment)"
                      OnMouseOut="() => OnSegmentMouseOut()" />

--- a/src/MudBlazor/Components/Chart/Charts/Rose.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Rose.razor
@@ -20,6 +20,7 @@
                      UserAttributes="@UserAttributes"
                      TooltipTemplate="@TooltipTemplate"
                      TooltipPositionFunc="@TooltipPositionFunc"
+                     TooltipScalingFactor="@TooltipScalingFactor"
                      OnPathClick="async (i) => await SetSelectedIndexAsync(i)"
                      OnMouseOver="(x) => OnSegmentMouseOver(x.Args, x.Segment)"
                      OnMouseOut="() => OnSegmentMouseOut()" />

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor
@@ -58,8 +58,8 @@
                               ShowTriangle="false"
                               StrokeWidth="0"
                               AnchorPositionX="@(kv.Value.X <= 10 ? ChartTooltipAnchorPositionX.Start : ChartTooltipAnchorPositionX.End)"
-                              FontSize="@ChartOptions.LabelFontSize"
-                              PaddingSize="@ChartOptions.LabelPadding"/>
+                              FontSizeStr="@(ChartOptions.LabelFontSize)"
+                              PaddingSize="@(ChartOptions.LabelPadding)"/>
             }
         }
         @* Draw edge labels last to have them at the top*@
@@ -83,8 +83,8 @@
                               Y="@edge.LabelY"
                               ShowTriangle="false"
                               StrokeWidth="0"
-                              FontSize="@ChartOptions!.LabelFontSize"
-                              PaddingSize="@ChartOptions.LabelPadding"/>
+                              FontSizeStr="@(ChartOptions!.LabelFontSize)"
+                              PaddingSize="@(ChartOptions.LabelPadding)"/>
             }
         }
         @MudChartParent?.CustomGraphics

--- a/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
+++ b/src/MudBlazor/Components/Chart/Charts/Sankey.razor.cs
@@ -59,6 +59,7 @@ namespace MudBlazor.Charts
         private List<ChartSeries<T>> _seriesData = [];
         private Dictionary<string, SankeyNode> _nodeLookup = [];
 
+
         /// <summary>
         /// The chart, if any, containing this component.
         /// </summary>

--- a/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
+++ b/src/MudBlazor/Components/Chart/Charts/ScatterPlot.razor
@@ -200,6 +200,9 @@
                 builder.AddAttribute(seq++, "Color", color);
                 builder.AddAttribute(seq++, "X", tooltipX);
                 builder.AddAttribute(seq++, "Y", tooltipY);
+                builder.AddAttribute(seq++, "FontSize", ChartOptions.TooltipFontSize * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "PaddingSize", 5.0 * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "StrokeWidth", 1.0 * TooltipScalingFactor);
                 builder.CloseComponent();
             }
         }

--- a/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
+++ b/src/MudBlazor/Components/Chart/Charts/StackedBar.razor
@@ -109,6 +109,9 @@
                 builder.AddAttribute(seq++, "Color", color);
                 builder.AddAttribute(seq++, "X", tooltipX);
                 builder.AddAttribute(seq++, "Y", tooltipY);
+                builder.AddAttribute(seq++, "FontSize", ChartOptions.TooltipFontSize * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "PaddingSize", 5.0 * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "StrokeWidth", 1.0 * TooltipScalingFactor);
                 builder.CloseComponent();
             }
         }

--- a/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
+++ b/src/MudBlazor/Components/Chart/Charts/TimeSeries.razor
@@ -180,6 +180,9 @@
                 builder.AddAttribute(seq++, "Color", color);
                 builder.AddAttribute(seq++, "X", tooltipX);
                 builder.AddAttribute(seq++, "Y", tooltipY);
+                builder.AddAttribute(seq++, "FontSize", ChartOptions.TooltipFontSize * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "PaddingSize", 5.0 * TooltipScalingFactor);
+                builder.AddAttribute(seq++, "StrokeWidth", 1.0 * TooltipScalingFactor);
                 builder.CloseComponent();
             }
         }

--- a/src/MudBlazor/Components/Chart/Models/Options/BarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/BarChartOptions.cs
@@ -34,6 +34,7 @@ public class BarChartOptions : DefaultBarChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/DonutChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/DonutChartOptions.cs
@@ -20,6 +20,7 @@ public class DonutChartOptions : PieChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/HeatMapChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/HeatMapChartOptions.cs
@@ -72,6 +72,7 @@ public class HeatMapChartOptions : DefaultChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/LineChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/LineChartOptions.cs
@@ -19,6 +19,7 @@ public class LineChartOptions : DefaultAxisLineChartOptions, IAxisLineChartOptio
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/PieChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/PieChartOptions.cs
@@ -41,6 +41,7 @@ public class PieChartOptions : DefaultRadialChartOptions, IHasValueLabelOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/RadarChartOptions.cs
@@ -116,6 +116,7 @@ public class RadarChartOptions : DefaultRadialChartOptions, IRadialChartOptions,
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/RoseChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/RoseChartOptions.cs
@@ -39,6 +39,7 @@ public class RoseChartOptions : DefaultRadialChartOptions, IHasValueLabelOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/SankeyChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/SankeyChartOptions.cs
@@ -136,6 +136,7 @@ public class SankeyChartOptions : DefaultChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/ScatterPlotChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/ScatterPlotChartOptions.cs
@@ -57,6 +57,7 @@ public class ScatterPlotChartOptions : DefaultAxisLineChartOptions, IAxisLineCha
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/StackedBarChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/StackedBarChartOptions.cs
@@ -30,6 +30,7 @@ public class StackedBarChartOptions : DefaultBarChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Models/Options/TimeSeriesChartOptions.cs
+++ b/src/MudBlazor/Components/Chart/Models/Options/TimeSeriesChartOptions.cs
@@ -61,6 +61,7 @@ public class TimeSeriesChartOptions : DefaultAxisLineChartOptions
         ShowToolTips = options.ShowToolTips,
         TooltipTitleFormat = options.TooltipTitleFormat,
         TooltipSubtitleFormat = options.TooltipSubtitleFormat,
+        TooltipFontSize = options.TooltipFontSize,
         ChartPalette = options.ChartPalette,
     };
 }

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor
@@ -38,7 +38,7 @@
     <text @ref="_text"
           x="@ToS(_textBbox.X)"
           y="@ToS(_textBbox.Y - (HasSubtitle ? _textBbox.Height : 0))"
-          font-size="@FontSize"
+          font-size="@(FontSize.ToStr() + "px")"
           fill="@FontColor"
           text-anchor="middle"
           stroke="black"

--- a/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
+++ b/src/MudBlazor/Components/Chart/Parts/ChartTooltip.razor.cs
@@ -63,19 +63,38 @@ public partial class ChartTooltip : ComponentBase
     /// The font size of the <see cref="Title"/> and <see cref="Subtitle"/>.
     /// </summary>
     /// <remarks>
+    /// Defaults to <c>12.0</c>.
+    /// </remarks>
+    [Parameter]
+    public double FontSize { get; set; } = 12.0;
+
+    /// <summary>
+    /// The font size of the <see cref="Title"/> and <see cref="Subtitle"/>.
+    /// </summary>
+    /// <remarks>
     /// Defaults to <c>"12px"</c>.
     /// </remarks>
     [Parameter]
-    public string FontSize { get; set; } = "12px";
+    public string? FontSizeStr
+    {
+        get => FontSize.ToStr() + "px";
+        set
+        {
+            if (value != null && value.EndsWith("px") && double.TryParse(value.AsSpan(0, value.Length - 2), out var val))
+            {
+                FontSize = val;
+            }
+        }
+    }
 
     /// <summary>
     /// The padding size of the tooltip background in px.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>5</c>.
+    /// Defaults to <c>5.0</c>.
     /// </remarks>
     [Parameter]
-    public int PaddingSize { get; set; } = 5;
+    public double PaddingSize { get; set; } = 5.0;
 
     /// <summary>
     /// The color of the <see cref="Title"/> and <see cref="Subtitle"/>.
@@ -90,10 +109,10 @@ public partial class ChartTooltip : ComponentBase
     /// The width of the border.
     /// </summary>
     /// <remarks>
-    /// Defaults to <c>1</c>.
+    /// Defaults to <c>1.0</c>.
     /// </remarks>
     [Parameter]
-    public int StrokeWidth { get; set; } = 1;
+    public double StrokeWidth { get; set; } = 1.0;
 
     /// <summary>
     /// Whether to show the triangle pointing down.
@@ -118,7 +137,7 @@ public partial class ChartTooltip : ComponentBase
 
     private double _previousX;
     private double _previousY;
-    private string? _previousFontSize;
+    private double _previousFontSize;
     private string? _previousTitle;
     private string? _previousSubtitle;
 
@@ -126,7 +145,7 @@ public partial class ChartTooltip : ComponentBase
     {
         await base.OnAfterRenderAsync(firstRender);
 
-        if (firstRender || FontSize != _previousFontSize || Title != _previousTitle || Subtitle != _previousSubtitle || _previousX != X || _previousY != Y)
+        if (firstRender || Math.Abs(FontSize - _previousFontSize) > 1e-6 || Title != _previousTitle || Subtitle != _previousSubtitle || _previousX != X || _previousY != Y)
         {
             await RecalculateBoxWidthAsync();
         }


### PR DESCRIPTION
This change addresses an issue where tooltips in Pie and Donut charts appeared larger than in other chart types due to SVG coordinate scaling. It introduces a global TooltipFontSize property in ChartOptions and a TooltipScalingFactor in base chart classes to ensure consistent rendering across all charts. It also maintains backward compatibility for the ChartTooltip component.

---
*PR created automatically by Jules for task [16714314828065089851](https://jules.google.com/task/16714314828065089851) started by @Anu6is*